### PR TITLE
chore: fix loop span

### DIFF
--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -175,7 +175,7 @@ impl HashBuilder {
 
         let mut i = 0usize;
         loop {
-            let _span = tracing::trace_span!(target: "trie::hash_builder", "loop", i, ?current, build_extensions);
+            let _span = tracing::trace_span!(target: "trie::hash_builder", "loop", i, ?current, build_extensions).entered();
 
             let preceding_exists = !self.groups.is_empty();
             let preceding_len = self.groups.len().saturating_sub(1);

--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -174,20 +174,8 @@ impl HashBuilder {
         trace!(target: "trie::hash_builder", ?current, ?succeeding, "updating merkle tree");
 
         let mut i = 0usize;
-        let span = tracing::trace_span!(
-            target: "trie::hash_builder",
-            "loop",
-            i = tracing::field::Empty,
-            current = tracing::field::Empty,
-            build_extensions = tracing::field::Empty,
-        )
-        .entered();
         loop {
-            if !span.is_disabled() {
-                span.record("i", i);
-                span.record("current", &format!("{current:?}"));
-                span.record("build_extensions", build_extensions);
-            }
+            let _span = tracing::trace_span!(target: "trie::hash_builder", "loop", i, ?current, build_extensions);
 
             let preceding_exists = !self.groups.is_empty();
             let preceding_len = self.groups.len().saturating_sub(1);


### PR DESCRIPTION
## Description

`Span::record` does not override the existing field value, but appends the duplicate field entry instead.