### PR TITLE
feat: leaf node decoding

### DIFF
--- a/src/nodes/leaf.rs
+++ b/src/nodes/leaf.rs
@@ -1,6 +1,6 @@
 use super::{super::Nibbles, rlp_node};
 use alloy_primitives::Bytes;
-use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header, EMPTY_STRING_CODE};
+use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header};
 use core::fmt;
 
 #[allow(unused_imports)]

--- a/src/nodes/leaf.rs
+++ b/src/nodes/leaf.rs
@@ -107,16 +107,15 @@ impl Encodable for LeafNodeRef<'_> {
 
 impl<'a> LeafNodeRef<'a> {
     /// Creates a new leaf node with the given key and value.
-    pub fn new(key: &'a Nibbles, value: &'a [u8]) -> Self {
+    pub const fn new(key: &'a Nibbles, value: &'a [u8]) -> Self {
         Self { key, value }
     }
 
     /// Returns the length of RLP encoded fields of leaf node.
     fn rlp_payload_length(&self) -> usize {
         let mut encoded_key_len = self.key.len() / 2 + 1;
-        let odd_nibbles = self.key.len() % 2 != 0;
-        // For leaf nodes the first byte can be greater than 0x80 only if the key has odd length.
-        if encoded_key_len != 1 || (odd_nibbles && 0x30 | self.key[0] >= EMPTY_STRING_CODE) {
+        // For leaf nodes the first byte cannot be greater than 0x80.
+        if encoded_key_len != 1 {
             encoded_key_len += length_of_length(encoded_key_len);
         }
         encoded_key_len + Encodable::length(&self.value)

--- a/src/nodes/leaf.rs
+++ b/src/nodes/leaf.rs
@@ -54,9 +54,9 @@ impl Decodable for LeafNode {
             0x20 => None,
             _ => return Err(alloy_rlp::Error::Custom("node is not leaf")),
         };
-        let is_odd = first.is_some();
         let rest = encoded_key[1..].iter().flat_map(|b| [b >> 4, b & 0x0f]);
 
+        let is_odd = first.is_some();
         let len = (encoded_key.len() - 1) * 2 + is_odd as usize;
         let mut nibbles = Vec::with_capacity(len);
         unsafe {

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -14,7 +14,7 @@ mod extension;
 pub use extension::ExtensionNode;
 
 mod leaf;
-pub use leaf::LeafNode;
+pub use leaf::{LeafNode, LeafNodeRef};
 
 /// The range of valid child indexes.
 pub const CHILD_INDEX_RANGE: Range<u8> = 0..16;


### PR DESCRIPTION
## Description

Rename existing `LeafNode` to `LeafNodeRef`. Implement proper encoding instead of anon struct. Implement rlp decoding for `LeafNode`.