### PR TITLE
feat: extension node decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ alloy-rlp = { version = "0.3", default-features = false, features = ["derive"] }
 derive_more = "0.99"
 hashbrown = { version = "0.14", features = ["ahash", "inline-more"] }
 nybbles = { version = "0.2", default-features = false }
-smallvec = "1.11"
 tracing = { version = "0.1", default-features = false }
 
 # serde

--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -1,7 +1,7 @@
 //! The implementation of the hash builder.
 
 use super::{
-    nodes::{word_rlp, BranchNode, ExtensionNode, LeafNodeRef},
+    nodes::{word_rlp, BranchNode, ExtensionNodeRef, LeafNodeRef},
     BranchNodeCompact, Nibbles, TrieMask, EMPTY_ROOT_HASH,
 };
 use crate::HashMap;
@@ -257,7 +257,7 @@ impl HashBuilder {
                 self.update_masks(&current, len_from);
                 let stack_last =
                     self.stack.pop().expect("there should be at least one stack item; qed");
-                let extension_node = ExtensionNode::new(&short_node_key, &stack_last);
+                let extension_node = ExtensionNodeRef::new(&short_node_key, &stack_last);
                 trace!(target: "trie::hash_builder", ?extension_node, "pushing extension node");
                 trace!(target: "trie::hash_builder", rlp = {
                     self.rlp_buf.clear();

--- a/src/nodes/extension.rs
+++ b/src/nodes/extension.rs
@@ -53,7 +53,7 @@ impl Decodable for ExtensionNode {
         };
 
         let key = unpack_path_to_nibbles(first, &encoded_key[1..]);
-        let child = Vec::from(&bytes[..]);
+        let child = Vec::from(bytes);
         Ok(Self { key, child })
     }
 }

--- a/src/nodes/extension.rs
+++ b/src/nodes/extension.rs
@@ -1,10 +1,10 @@
-use super::{super::Nibbles, rlp_node};
-use alloy_rlp::{BufMut, Encodable};
+use super::{super::Nibbles, rlp_node, unpack_path_to_nibbles};
+use alloy_primitives::Bytes;
+use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header};
 use core::fmt;
-use smallvec::SmallVec;
 
 #[allow(unused_imports)]
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::vec::Vec;
 
 /// An intermediate node that exists solely to compress the trie's paths. It contains a path segment
 /// (a shared prefix of keys) and a single child pointer. Essentially, an extension node can be
@@ -13,17 +13,98 @@ use alloc::{collections::BTreeMap, vec::Vec};
 /// The purpose of an extension node is to optimize the trie structure by collapsing multiple nodes
 /// with a single child into one node. This simplification reduces the space and computational
 /// complexity when performing operations on the trie.
-pub struct ExtensionNode<'a> {
-    /// A common prefix for keys. See [`Nibbles::encode_path_leaf`] for more information.
-    pub prefix: SmallVec<[u8; 36]>,
-    /// A pointer to the child.
-    pub node: &'a [u8],
+#[derive(PartialEq, Eq)]
+pub struct ExtensionNode {
+    /// The key for this extension node.
+    pub key: Nibbles,
+    /// A pointer to the child node.
+    pub child: Vec<u8>,
 }
 
-impl<'a> ExtensionNode<'a> {
-    /// Creates a new extension node with the given prefix and child.
-    pub fn new(prefix: &Nibbles, node: &'a [u8]) -> Self {
-        Self { prefix: prefix.encode_path_leaf(false), node }
+impl fmt::Debug for ExtensionNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExtensionNode")
+            .field("key", &self.key)
+            .field("child", &alloy_primitives::hex::encode(&self.child))
+            .finish()
+    }
+}
+
+impl Encodable for ExtensionNode {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.as_ref().encode(out)
+    }
+}
+
+impl Decodable for ExtensionNode {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut bytes = Header::decode_bytes(buf, true)?;
+
+        let encoded_key = Bytes::decode(&mut bytes)?;
+        if encoded_key.is_empty() {
+            return Err(alloy_rlp::Error::Custom("extension node key empty"));
+        }
+
+        // Retrieve first byte. If it's [Some], then the nibbles are odd.
+        let first = match encoded_key[0] & 0xf0 {
+            0x10 => Some(encoded_key[0] & 0x0f),
+            0x00 => None,
+            _ => return Err(alloy_rlp::Error::Custom("node is not extension")),
+        };
+
+        let key = unpack_path_to_nibbles(first, &encoded_key[1..]);
+        let child = Vec::from(&bytes[..]);
+        Ok(Self { key, child })
+    }
+}
+
+impl ExtensionNode {
+    /// Creates a new extension node with the given key and a pointer to the child.
+    pub fn new(key: Nibbles, child: Vec<u8>) -> Self {
+        Self { key, child }
+    }
+
+    /// Return extension node as [ExtensionNodeRef].
+    pub fn as_ref(&self) -> ExtensionNodeRef<'_> {
+        ExtensionNodeRef { key: &self.key, child: &self.child }
+    }
+}
+
+/// Reference to the extension node. See [ExtensionNode] from more information.
+pub struct ExtensionNodeRef<'a> {
+    /// The key for this extension node.
+    pub key: &'a Nibbles,
+    /// A pointer to the child node.
+    pub child: &'a [u8],
+}
+
+impl fmt::Debug for ExtensionNodeRef<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExtensionNodeRef")
+            .field("key", &self.key)
+            .field("node", &alloy_primitives::hex::encode(self.child))
+            .finish()
+    }
+}
+
+impl Encodable for ExtensionNodeRef<'_> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        Header { list: true, payload_length: self.rlp_payload_length() }.encode(out);
+        self.key.encode_path_leaf(false).as_slice().encode(out);
+        // Pointer to the child is already RLP encoded.
+        out.put_slice(self.child);
+    }
+
+    fn length(&self) -> usize {
+        let payload_length = self.rlp_payload_length();
+        payload_length + length_of_length(payload_length)
+    }
+}
+
+impl<'a> ExtensionNodeRef<'a> {
+    /// Creates a new extension node with the given key and a pointer to the child.
+    pub const fn new(key: &'a Nibbles, child: &'a [u8]) -> Self {
+        Self { key, child }
     }
 
     /// RLP encodes the node and returns either RLP(Node) or RLP(keccak(RLP(node))).
@@ -31,27 +112,30 @@ impl<'a> ExtensionNode<'a> {
         self.encode(buf);
         rlp_node(buf)
     }
-}
 
-impl Encodable for ExtensionNode<'_> {
-    fn encode(&self, out: &mut dyn BufMut) {
-        let h = alloy_rlp::Header {
-            list: true,
-            payload_length: self.prefix.as_slice().length() + self.node.len(),
-        };
-        h.encode(out);
-        // Slices have different RLP encoding from Vectors so we need to `as_slice()
-        self.prefix.as_slice().encode(out);
-        // The nodes are already RLP encoded
-        out.put_slice(self.node);
+    /// Returns the length of RLP encoded fields of extension node.
+    fn rlp_payload_length(&self) -> usize {
+        let mut encoded_key_len = self.key.len() / 2 + 1;
+        // For extension nodes the first byte cannot be greater than 0x80.
+        if encoded_key_len != 1 {
+            encoded_key_len += length_of_length(encoded_key_len);
+        }
+        encoded_key_len + self.child.len()
     }
 }
 
-impl fmt::Debug for ExtensionNode<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ExtensionNode")
-            .field("prefix", &alloy_primitives::hex::encode(&self.prefix))
-            .field("node", &alloy_primitives::hex::encode(self.node))
-            .finish()
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::hex;
+
+    #[test]
+    fn rlp_extension_node_roundtrip() {
+        let nibble = Nibbles::from_nibbles_unchecked(hex!("0604060f"));
+        let val = hex!("76657262");
+        let extension = ExtensionNode::new(nibble, val.to_vec());
+        let rlp = extension.as_ref().rlp(&mut vec![]);
+        assert_eq!(rlp, hex!("c88300646f76657262"));
+        assert_eq!(ExtensionNode::decode(&mut &rlp[..]).unwrap(), extension);
     }
 }

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -3,6 +3,7 @@
 use alloy_primitives::{keccak256, B256};
 use alloy_rlp::EMPTY_STRING_CODE;
 use core::ops::Range;
+use nybbles::Nibbles;
 
 #[allow(unused_imports)]
 use alloc::vec::Vec;
@@ -11,7 +12,7 @@ mod branch;
 pub use branch::{BranchNode, BranchNodeCompact};
 
 mod extension;
-pub use extension::ExtensionNode;
+pub use extension::{ExtensionNode, ExtensionNodeRef};
 
 mod leaf;
 pub use leaf::{LeafNode, LeafNodeRef};
@@ -38,4 +39,29 @@ pub fn word_rlp(word: &B256) -> Vec<u8> {
     arr[0] = EMPTY_STRING_CODE + 32;
     arr[1..].copy_from_slice(word.as_slice());
     arr.to_vec()
+}
+
+/// Unpack node path to nibbles.
+///
+/// NOTE: The first nibble should be less than or equal to `0xf` if provided.
+/// If first nibble is greater than `0xf`, the method will not panic, but initialize invalid nibbles
+/// instead.
+///
+/// ## Arguments
+///
+/// `first` - first nibble of the path if it is odd
+/// `rest` - rest of the nibbles packed
+pub(crate) fn unpack_path_to_nibbles(first: Option<u8>, rest: &[u8]) -> Nibbles {
+    let is_odd = first.is_some();
+    let len = rest.len() * 2 + is_odd as usize;
+    let mut nibbles = Vec::with_capacity(len);
+    unsafe {
+        let ptr: *mut u8 = nibbles.as_mut_ptr();
+        let rest = rest.iter().copied().flat_map(|b| [b >> 4, b & 0x0f]);
+        for (i, nibble) in first.into_iter().chain(rest).enumerate() {
+            ptr.add(i).write(nibble)
+        }
+        nibbles.set_len(len);
+    }
+    Nibbles::from_vec_unchecked(nibbles)
 }


### PR DESCRIPTION
## Description

Similar to https://github.com/alloy-rs/trie/pull/10, rename `ExtensionNode` to `ExtensionNodeRef` and introduce an owned `ExtensionNode`. Implement RLP decoding for it.