### PR TITLE
chore: bump proptest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 # arbitrary
 arbitrary = { version = "1.3", optional = true }
 derive_arbitrary = { version = "1.3", optional = true }
-proptest = { version = "1.4", optional = true }
-proptest-derive = { version = "0.4", optional = true }
+proptest = { version = "1.5", optional = true }
+proptest-derive = { version = "0.5", optional = true }
 
 [dev-dependencies]
 hash-db = "0.15"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,7 @@
     clippy::missing_const_for_fn,
     rustdoc::all
 )]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))] // TODO: https://github.com/proptest-rs/proptest/pull/427
-#![allow(unknown_lints, non_local_definitions)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
bumps proptest and gets rid of the non-local-definitions allow / associated TODO