### PR TITLE
feat: workflow to validate no_std compatibility

### DIFF
--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -1,0 +1,24 @@
+name: no_std
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-no-std:
+    name: check no_std ${{ matrix.features }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: riscv32imac-unknown-none-elf
+      - run: cargo check --target riscv32imac-unknown-none-elf --no-default-features
+


### PR DESCRIPTION
### Description

Adds a github action workflow that targets the `riscv32imac-unknown-none-elf` without default features to validate `no_std` compatibility.