### PR TITLE
feat: empty root node

### DIFF
--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -7,6 +7,7 @@ use super::{
 };
 use crate::HashMap;
 use alloy_primitives::{hex, keccak256, Bytes, B256};
+use alloy_rlp::EMPTY_STRING_CODE;
 use core::cmp;
 use tracing::trace;
 
@@ -139,7 +140,13 @@ impl HashBuilder {
             self.key.clear();
             self.value = HashBuilderValue::Bytes(vec![]);
         }
-        self.current_root()
+        let root = self.current_root();
+        if root == EMPTY_ROOT_HASH {
+            if let Some(proof_retainer) = self.proof_retainer.as_mut() {
+                proof_retainer.retain(&Nibbles::default(), &[EMPTY_STRING_CODE])
+            }
+        }
+        root
     }
 
     fn set_key_value<T: Into<HashBuilderValue>>(&mut self, key: Nibbles, value: T) {

--- a/src/proof/error.rs
+++ b/src/proof/error.rs
@@ -21,6 +21,8 @@ pub enum ProofVerificationError {
         /// Expected value.
         expected: Option<Bytes>,
     },
+    /// Encountered unexpected empty root node.
+    UnexpectedEmptyRoot,
     /// Error during RLP decoding of trie node.
     Rlp(alloy_rlp::Error),
 }
@@ -48,6 +50,9 @@ impl fmt::Display for ProofVerificationError {
             }
             ProofVerificationError::ValueMismatch { path, got, expected } => {
                 write!(f, "value mismatch at path {path:?}. got: {got:?}. expected: {expected:?}")
+            }
+            ProofVerificationError::UnexpectedEmptyRoot => {
+                write!(f, "unexpected empty root node")
             }
             ProofVerificationError::Rlp(error) => fmt::Display::fmt(error, f),
         }

--- a/src/proof/retainer.rs
+++ b/src/proof/retainer.rs
@@ -39,7 +39,7 @@ impl ProofRetainer {
 
     /// Retain the proof if the key matches any of the targets.
     pub fn retain(&mut self, prefix: &Nibbles, proof: &[u8]) {
-        if self.matches(prefix) {
+        if prefix.is_empty() || self.matches(prefix) {
             self.proofs.insert(prefix.clone(), Bytes::from(proof.to_vec()));
         }
     }

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -132,7 +132,7 @@ fn process_branch(
                                 return Ok(Some(child_leaf.value));
                             }
                             TrieNode::EmptyRoot => {
-                                todo!()
+                                return Err(ProofVerificationError::UnexpectedEmptyRoot)
                             }
                         }
                     };


### PR DESCRIPTION
## Description

Adds `TrieNode::EmptyRoot` variant. Proofs for empty trie now contain at least empty root node.