### PR TITLE
feat: replace std/hashbrown with alloy_primitives::map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,30 @@ repository = "https://github.com/alloy-rs/trie"
 exclude = [".github/", "deny.toml", "release.toml", "rustfmt.toml"]
 
 [dependencies]
-alloy-primitives = { version = "0.8", default-features = false, features = ["rlp"] }
-alloy-rlp = { version = "0.3.8", default-features = false, features = ["derive"] }
-derive_more = { version = "1", default-features = false, features = ["add", "add_assign", "deref", "from", "not"] }
-hashbrown = { version = "0.14", features = ["ahash", "inline-more"] }
+alloy-primitives = { version = "0.8.5", default-features = false, features = [
+    "rlp",
+    "map",
+] }
+alloy-rlp = { version = "0.3.8", default-features = false, features = [
+    "derive",
+] }
+derive_more = { version = "1", default-features = false, features = [
+    "add",
+    "add_assign",
+    "deref",
+    "from",
+    "not",
+] }
 nybbles = { version = "0.2", default-features = false }
-smallvec = { version = "1.0", default-features = false, features = ["const_new"] }
+smallvec = { version = "1.0", default-features = false, features = [
+    "const_new",
+] }
 tracing = { version = "0.1", default-features = false }
 
 # serde
-serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = [
+    "derive",
+], optional = true }
 
 # arbitrary
 arbitrary = { version = "1.3", optional = true }
@@ -44,9 +58,16 @@ triehash = "0.8.4"
 criterion = "0.5"
 
 [features]
-default = ["std"]
-std = ["alloy-primitives/std", "alloy-rlp/std", "derive_more/std", "nybbles/std", "tracing/std", "serde?/std"]
-serde = ["dep:serde", "alloy-primitives/serde", "hashbrown/serde", "nybbles/serde"]
+default = ["std", "alloy-primitives/default"]
+std = [
+    "alloy-primitives/std",
+    "alloy-rlp/std",
+    "derive_more/std",
+    "nybbles/std",
+    "tracing/std",
+    "serde?/std",
+]
+serde = ["dep:serde", "alloy-primitives/serde", "nybbles/serde"]
 arbitrary = [
     "std",
     "dep:arbitrary",

--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -80,7 +80,7 @@ impl HashBuilder {
     /// Call [HashBuilder::split] to get the updates to branch nodes.
     pub fn set_updates(&mut self, retain_updates: bool) {
         if retain_updates {
-            self.updated_branch_nodes = Some(HashMap::new());
+            self.updated_branch_nodes = Some(HashMap::default());
         }
     }
 
@@ -447,13 +447,13 @@ mod tests {
     // No hashing involved
     fn assert_trie_root<I, K, V>(iter: I)
     where
-        I: Iterator<Item = (K, V)>,
+        I: IntoIterator<Item = (K, V)>,
         K: AsRef<[u8]> + Ord,
         V: AsRef<[u8]>,
     {
         let mut hb = HashBuilder::default();
 
-        let data = iter.collect::<BTreeMap<_, _>>();
+        let data = iter.into_iter().collect::<BTreeMap<_, _>>();
         data.iter().for_each(|(key, val)| {
             let nibbles = Nibbles::unpack(key);
             hb.add_leaf(nibbles, val.as_ref());
@@ -540,13 +540,13 @@ mod tests {
 
     #[test]
     fn test_root_raw_data() {
-        let data = vec![
+        let data = [
             (hex!("646f").to_vec(), hex!("76657262").to_vec()),
             (hex!("676f6f64").to_vec(), hex!("7075707079").to_vec()),
             (hex!("676f6b32").to_vec(), hex!("7075707079").to_vec()),
             (hex!("676f6b34").to_vec(), hex!("7075707079").to_vec()),
         ];
-        assert_trie_root(data.into_iter());
+        assert_trie_root(data);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,13 +30,8 @@ pub mod proof;
 mod mask;
 pub use mask::TrieMask;
 
-#[cfg(feature = "std")]
-use hashbrown as _;
-#[cfg(feature = "std")]
-pub use std::collections::HashMap;
-
-#[cfg(not(feature = "std"))]
-pub use hashbrown::HashMap;
+#[doc(hidden)]
+pub use alloy_primitives::map::HashMap;
 
 #[doc(no_inline)]
 pub use nybbles::{self, Nibbles};

--- a/src/proof/retainer.rs
+++ b/src/proof/retainer.rs
@@ -15,9 +15,9 @@ pub struct ProofRetainer {
     proofs: BTreeMap<Nibbles, Bytes>,
 }
 
-impl core::iter::FromIterator<Nibbles> for ProofRetainer {
+impl FromIterator<Nibbles> for ProofRetainer {
     fn from_iter<T: IntoIterator<Item = Nibbles>>(iter: T) -> Self {
-        Self::new(iter.into_iter().collect())
+        Self::new(FromIterator::from_iter(iter))
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/alloy-rs/trie/issues/41

Left `BTreeMap` in `ProofRetainer`, needs clarification whether it can be changed to `HashMap`