### PR TITLE
perf: inline RLP encode functions

### DIFF
--- a/src/nodes/branch.rs
+++ b/src/nodes/branch.rs
@@ -30,10 +30,12 @@ impl fmt::Debug for BranchNode {
 }
 
 impl Encodable for BranchNode {
+    #[inline]
     fn encode(&self, out: &mut dyn BufMut) {
         self.as_ref().encode(out)
     }
 
+    #[inline]
     fn length(&self) -> usize {
         self.as_ref().length()
     }
@@ -115,6 +117,7 @@ impl fmt::Debug for BranchNodeRef<'_> {
 /// Encode it as a 17-element list consisting of 16 slots that correspond to
 /// each child of the node (0-f) and an additional slot for a value.
 impl Encodable for BranchNodeRef<'_> {
+    #[inline]
     fn encode(&self, out: &mut dyn BufMut) {
         Header { list: true, payload_length: self.rlp_payload_length() }.encode(out);
 
@@ -133,6 +136,7 @@ impl Encodable for BranchNodeRef<'_> {
         out.put_u8(EMPTY_STRING_CODE);
     }
 
+    #[inline]
     fn length(&self) -> usize {
         let payload_length = self.rlp_payload_length();
         payload_length + length_of_length(payload_length)

--- a/src/nodes/extension.rs
+++ b/src/nodes/extension.rs
@@ -33,10 +33,12 @@ impl fmt::Debug for ExtensionNode {
 }
 
 impl Encodable for ExtensionNode {
+    #[inline]
     fn encode(&self, out: &mut dyn BufMut) {
         self.as_ref().encode(out)
     }
 
+    #[inline]
     fn length(&self) -> usize {
         self.as_ref().length()
     }
@@ -99,6 +101,7 @@ impl fmt::Debug for ExtensionNodeRef<'_> {
 }
 
 impl Encodable for ExtensionNodeRef<'_> {
+    #[inline]
     fn encode(&self, out: &mut dyn BufMut) {
         Header { list: true, payload_length: self.rlp_payload_length() }.encode(out);
         self.key.encode_path_leaf(false).as_slice().encode(out);
@@ -106,6 +109,7 @@ impl Encodable for ExtensionNodeRef<'_> {
         out.put_slice(self.child);
     }
 
+    #[inline]
     fn length(&self) -> usize {
         let payload_length = self.rlp_payload_length();
         payload_length + length_of_length(payload_length)

--- a/src/nodes/leaf.rs
+++ b/src/nodes/leaf.rs
@@ -31,10 +31,12 @@ impl fmt::Debug for LeafNode {
 }
 
 impl Encodable for LeafNode {
+    #[inline]
     fn encode(&self, out: &mut dyn BufMut) {
         self.as_ref().encode(out)
     }
 
+    #[inline]
     fn length(&self) -> usize {
         self.as_ref().length()
     }
@@ -98,12 +100,14 @@ impl fmt::Debug for LeafNodeRef<'_> {
 
 /// Manual implementation of encoding for the leaf node of Merkle Patricia Trie.
 impl Encodable for LeafNodeRef<'_> {
+    #[inline]
     fn encode(&self, out: &mut dyn BufMut) {
         Header { list: true, payload_length: self.rlp_payload_length() }.encode(out);
         self.key.encode_path_leaf(true).as_slice().encode(out);
         self.value.encode(out);
     }
 
+    #[inline]
     fn length(&self) -> usize {
         let payload_length = self.rlp_payload_length();
         payload_length + length_of_length(payload_length)

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -35,6 +35,7 @@ pub enum TrieNode {
 }
 
 impl Encodable for TrieNode {
+    #[inline]
     fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
         match self {
             Self::EmptyRoot => {
@@ -46,6 +47,7 @@ impl Encodable for TrieNode {
         }
     }
 
+    #[inline]
     fn length(&self) -> usize {
         match self {
             Self::EmptyRoot => 1,


### PR DESCRIPTION
Avoid dynamic dispatch in RLP encode implementations by inlining them