### PR TITLE
port: from `reth-trie-common` to `alloy-trie`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,12 @@ alloy-primitives = { version = "0.8.5", default-features = false, features = [
 ] }
 alloy-rlp = { version = "0.3.8", default-features = false, features = [
     "derive",
+    "arrayvec"
 ] }
+
+alloy-consensus = { version = "0.3.6", default-features = false }
+alloy-genesis = { version = "0.3.6", default-features = false }
+
 
 arrayvec = { version = "0.7", default-features = false }
 derive_more = { version = "1", default-features = false, features = [
@@ -47,11 +52,26 @@ serde = { version = "1.0", default-features = false, features = [
     "derive",
 ], optional = true }
 
+
+# reth
+revm-primitives = "10.0.0"
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", package = "reth-primitives-traits", tag = "v1.0.8" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", package = "reth-codecs", tag = "v1.0.8" }
+
 # arbitrary
 arbitrary = { version = "1.3", optional = true }
 derive_arbitrary = { version = "1.3", optional = true }
 proptest = { version = "1.5", optional = true }
 proptest-derive = { version = "0.5", optional = true }
+
+# misc
+bytes = "1.5"
+itertools = "0.13"
+
+# `test-utils` feature
+hash-db = { version = "=0.15.2", optional = true }
+plain_hasher = { version = "0.2", optional = true }
+
 
 [dev-dependencies]
 hash-db = "0.15"
@@ -60,7 +80,7 @@ triehash = "0.8.4"
 criterion = "0.5"
 
 [features]
-default = ["std", "alloy-primitives/default"]
+default = ["std", "alloy-primitives/default", "serde"]
 std = [
     "alloy-primitives/std",
     "alloy-rlp/std",
@@ -85,6 +105,8 @@ arbitrary = [
     "alloy-primitives/arbitrary",
     "nybbles/arbitrary",
 ]
+test-utils = ["dep:plain_hasher", "dep:hash-db", "arbitrary"]
+
 
 [[bench]]
 name = "bench"

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,0 +1,184 @@
+use crate::root::storage_root_unhashed;
+use alloy_consensus::{constants::KECCAK_EMPTY, EMPTY_ROOT_HASH};
+use alloy_genesis::GenesisAccount;
+use alloy_primitives::{keccak256, B256, U256};
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+use reth_primitives_traits::Account;
+use revm_primitives::AccountInfo;
+
+/// An Ethereum account as represented in the trie.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, RlpEncodable, RlpDecodable)]
+pub struct TrieAccount {
+    /// Account nonce.
+    pub nonce: u64,
+    /// Account balance.
+    pub balance: U256,
+    /// Account's storage root.
+    pub storage_root: B256,
+    /// Hash of the account's bytecode.
+    pub code_hash: B256,
+}
+
+impl TrieAccount {
+    /// Get account's storage root.
+    pub const fn storage_root(&self) -> B256 {
+        self.storage_root
+    }
+}
+
+impl From<GenesisAccount> for TrieAccount {
+    fn from(account: GenesisAccount) -> Self {
+        let storage_root = account
+            .storage
+            .map(|storage| {
+                storage_root_unhashed(
+                    storage
+                        .into_iter()
+                        .filter(|(_, value)| !value.is_zero())
+                        .map(|(slot, value)| (slot, U256::from_be_bytes(*value))),
+                )
+            })
+            .unwrap_or(EMPTY_ROOT_HASH);
+
+        Self {
+            nonce: account.nonce.unwrap_or_default(),
+            balance: account.balance,
+            storage_root,
+            code_hash: account.code.map_or(KECCAK_EMPTY, keccak256),
+        }
+    }
+}
+
+impl From<(Account, B256)> for TrieAccount {
+    fn from((account, storage_root): (Account, B256)) -> Self {
+        Self {
+            nonce: account.nonce,
+            balance: account.balance,
+            storage_root,
+            code_hash: account.bytecode_hash.unwrap_or(KECCAK_EMPTY),
+        }
+    }
+}
+
+impl From<(AccountInfo, B256)> for TrieAccount {
+    fn from((account, storage_root): (AccountInfo, B256)) -> Self {
+        Self {
+            nonce: account.nonce,
+            balance: account.balance,
+            storage_root,
+            code_hash: account.code_hash,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::Bytes;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_from_genesis_account_with_default_values() {
+        let genesis_account = GenesisAccount::default();
+
+        // Convert the GenesisAccount to a TrieAccount
+        let trie_account: TrieAccount = genesis_account.into();
+
+        // Check the fields are properly set.
+        assert_eq!(trie_account.nonce, 0);
+        assert_eq!(trie_account.balance, U256::default());
+        assert_eq!(trie_account.storage_root(), EMPTY_ROOT_HASH);
+        assert_eq!(trie_account.code_hash, KECCAK_EMPTY);
+
+        // Check that the default Account converts to the same TrieAccount
+        assert_eq!(Into::<TrieAccount>::into((Account::default(), EMPTY_ROOT_HASH)), trie_account);
+
+        // Check that the default AccountInfo converts to the same TrieAccount
+        assert_eq!(
+            Into::<TrieAccount>::into((AccountInfo::default(), EMPTY_ROOT_HASH)),
+            trie_account
+        );
+    }
+
+    #[test]
+    fn test_from_genesis_account_with_values() {
+        // Create a GenesisAccount with specific values
+        let mut storage = BTreeMap::new();
+        storage.insert(B256::from([0x01; 32]), B256::from([0x02; 32]));
+
+        let genesis_account = GenesisAccount {
+            nonce: Some(10),
+            balance: U256::from(1000),
+            code: Some(Bytes::from(vec![0x60, 0x61])),
+            storage: Some(storage),
+            private_key: None,
+        };
+
+        // Convert the GenesisAccount to a TrieAccount
+        let trie_account: TrieAccount = genesis_account.into();
+
+        let expected_storage_root = storage_root_unhashed(BTreeMap::from([(
+            B256::from([0x01; 32]),
+            U256::from_be_bytes(*B256::from([0x02; 32])),
+        )]));
+
+        // Check that the fields are properly set.
+        assert_eq!(trie_account.nonce, 10);
+        assert_eq!(trie_account.balance, U256::from(1000));
+        assert_eq!(trie_account.storage_root(), expected_storage_root);
+        assert_eq!(trie_account.code_hash, keccak256([0x60, 0x61]));
+
+        // Check that the Account converts to the same TrieAccount
+        assert_eq!(
+            Into::<TrieAccount>::into((
+                Account {
+                    nonce: 10,
+                    balance: U256::from(1000),
+                    bytecode_hash: Some(keccak256([0x60, 0x61]))
+                },
+                expected_storage_root
+            )),
+            trie_account
+        );
+
+        // Check that the AccountInfo converts to the same TrieAccount
+        assert_eq!(
+            Into::<TrieAccount>::into((
+                AccountInfo {
+                    nonce: 10,
+                    balance: U256::from(1000),
+                    code_hash: keccak256([0x60, 0x61]),
+                    ..Default::default()
+                },
+                expected_storage_root
+            )),
+            trie_account
+        );
+    }
+
+    #[test]
+    fn test_from_genesis_account_with_zeroed_storage_values() {
+        // Create a GenesisAccount with storage containing zero values
+        let storage = BTreeMap::from([(B256::from([0x01; 32]), B256::from([0x00; 32]))]);
+
+        let genesis_account = GenesisAccount {
+            nonce: Some(3),
+            balance: U256::from(300),
+            code: None,
+            storage: Some(storage),
+            private_key: None,
+        };
+
+        // Convert the GenesisAccount to a TrieAccount
+        let trie_account: TrieAccount = genesis_account.into();
+
+        // Check the fields are properly set.
+        assert_eq!(trie_account.nonce, 3);
+        assert_eq!(trie_account.balance, U256::from(300));
+        // Zero values in storage should result in EMPTY_ROOT_HASH
+        assert_eq!(trie_account.storage_root(), EMPTY_ROOT_HASH);
+        // No code provided, so code hash should be KECCAK_EMPTY
+        assert_eq!(trie_account.code_hash, KECCAK_EMPTY);
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,30 @@ pub use nodes::BranchNodeCompact;
 pub mod hash_builder;
 pub use hash_builder::HashBuilder;
 
+// imported from `reth-trie-common`
 pub mod proof;
 
 mod mask;
 pub use mask::TrieMask;
+
+mod account;
+pub use account::TrieAccount;
+
+mod nibbles;
+pub use nibbles::{StoredNibbles, StoredNibblesSubKey};
+
+mod storage;
+pub use storage::StorageTrieEntry;
+
+mod subnode;
+pub use subnode::StoredSubNode;
+
+mod proofs;
+#[cfg(any(test, feature = "test-utils"))]
+pub use proofs::triehash;
+pub use proofs::*;
+
+pub mod root;
 
 #[doc(hidden)]
 pub use alloy_primitives::map::HashMap;
@@ -48,6 +68,8 @@ where
     K: AsRef<[u8]> + Ord,
     V: AsRef<[u8]>,
 {
+    use ::triehash::trie_root;
+
     struct Keccak256Hasher;
     impl hash_db::Hasher for Keccak256Hasher {
         type Out = alloy_primitives::B256;
@@ -64,5 +86,5 @@ where
     // the incoming keys are already hashed, which makes sense given
     // we're going to be using the Hashed tables & pre-hash the data
     // on the way in.
-    triehash::trie_root::<Keccak256Hasher, _, _, _>(iter)
+    trie_root::<Keccak256Hasher, _, _, _>(iter)
 }

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -1,0 +1,123 @@
+use bytes::Buf;
+use derive_more::Deref;
+use reth_codecs::Compact;
+
+use nybbles::Nibbles;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// The representation of nibbles of the merkle trie stored in the database.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    derive_more::Index,
+)]
+pub struct StoredNibbles(pub Nibbles);
+
+impl From<Nibbles> for StoredNibbles {
+    #[inline]
+    fn from(value: Nibbles) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Vec<u8>> for StoredNibbles {
+    #[inline]
+    fn from(value: Vec<u8>) -> Self {
+        Self(Nibbles::from_nibbles_unchecked(value))
+    }
+}
+
+impl PartialEq<[u8]> for StoredNibbles {
+    #[inline]
+    fn eq(&self, other: &[u8]) -> bool {
+        self.0.as_slice() == other
+    }
+}
+
+impl PartialOrd<[u8]> for StoredNibbles {
+    #[inline]
+    fn partial_cmp(&self, other: &[u8]) -> Option<std::cmp::Ordering> {
+        self.0.as_slice().partial_cmp(other)
+    }
+}
+
+impl core::borrow::Borrow<[u8]> for StoredNibbles {
+    #[inline]
+    fn borrow(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl Compact for StoredNibbles {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        buf.put_slice(self.0.as_slice());
+        self.0.len()
+    }
+
+    fn from_compact(mut buf: &[u8], len: usize) -> (Self, &[u8]) {
+        let nibbles = &buf[..len];
+        buf.advance(len);
+        (Self(Nibbles::from_nibbles_unchecked(nibbles)), buf)
+    }
+}
+
+/// The representation of nibbles of the merkle trie stored in the database.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord, Hash, Deref)]
+pub struct StoredNibblesSubKey(pub Nibbles);
+
+impl From<Nibbles> for StoredNibblesSubKey {
+    #[inline]
+    fn from(value: Nibbles) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Vec<u8>> for StoredNibblesSubKey {
+    #[inline]
+    fn from(value: Vec<u8>) -> Self {
+        Self(Nibbles::from_nibbles_unchecked(value))
+    }
+}
+
+impl From<StoredNibblesSubKey> for Nibbles {
+    #[inline]
+    fn from(value: StoredNibblesSubKey) -> Self {
+        value.0
+    }
+}
+
+impl Compact for StoredNibblesSubKey {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        assert!(self.0.len() <= 64);
+
+        // right-pad with zeros
+        buf.put_slice(&self.0[..]);
+        static ZERO: &[u8; 64] = &[0; 64];
+        buf.put_slice(&ZERO[self.0.len()..]);
+
+        buf.put_u8(self.0.len() as u8);
+        64 + 1
+    }
+
+    fn from_compact(buf: &[u8], _len: usize) -> (Self, &[u8]) {
+        let len = buf[64] as usize;
+        (Self(Nibbles::from_nibbles_unchecked(&buf[..len])), &buf[65..])
+    }
+}
+

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -1,0 +1,241 @@
+//! Merkle trie proofs.
+
+use crate::{nodes::TrieNode, proof::{verify_proof, ProofNodes, ProofVerificationError}, Nibbles, TrieAccount};
+use alloy_consensus::EMPTY_ROOT_HASH;
+use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy_rlp::{encode_fixed_size, Decodable};
+use itertools::Itertools;
+use reth_primitives_traits::{constants::KECCAK_EMPTY, Account};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// The state multiproof of target accounts and multiproofs of their storage tries.
+/// Multiproof is effectively a state subtrie that only contains the nodes
+/// in the paths of target accounts.
+#[derive(Clone, Default, Debug)]
+pub struct MultiProof {
+    /// State trie multiproof for requested accounts.
+    pub account_subtree: ProofNodes,
+    /// Storage trie multiproofs.
+    pub storages: HashMap<B256, StorageMultiProof>,
+}
+
+impl MultiProof {
+    /// Construct the account proof from the multiproof.
+    pub fn account_proof(
+        &self,
+        address: Address,
+        slots: &[B256],
+    ) -> Result<AccountProof, alloy_rlp::Error> {
+        let hashed_address = keccak256(address);
+        let nibbles = Nibbles::unpack(hashed_address);
+
+        // Retrieve the account proof.
+        let proof = self
+            .account_subtree
+            .matching_nodes_iter(&nibbles)
+            .sorted_by(|a, b| a.0.cmp(b.0))
+            .map(|(_, node)| node.clone())
+            .collect::<Vec<_>>();
+
+        // Inspect the last node in the proof. If it's a leaf node with matching suffix,
+        // then the node contains the encoded trie account.
+        let info = 'info: {
+            if let Some(last) = proof.last() {
+                if let TrieNode::Leaf(leaf) = TrieNode::decode(&mut &last[..])? {
+                    if nibbles.ends_with(&leaf.key) {
+                        let account = TrieAccount::decode(&mut &leaf.value[..])?;
+                        break 'info Some(Account {
+                            balance: account.balance,
+                            nonce: account.nonce,
+                            bytecode_hash: (account.code_hash != KECCAK_EMPTY)
+                                .then_some(account.code_hash),
+                        })
+                    }
+                }
+            }
+            None
+        };
+
+        // Retrieve proofs for requested storage slots.
+        let storage_multiproof = self.storages.get(&hashed_address);
+        let storage_root = storage_multiproof.map(|m| m.root).unwrap_or(EMPTY_ROOT_HASH);
+        let mut storage_proofs = Vec::with_capacity(slots.len());
+        for slot in slots {
+            let proof = if let Some(multiproof) = &storage_multiproof {
+                multiproof.storage_proof(*slot)?
+            } else {
+                StorageProof::new(*slot)
+            };
+            storage_proofs.push(proof);
+        }
+        Ok(AccountProof { address, info, proof, storage_root, storage_proofs })
+    }
+}
+
+/// The merkle multiproof of storage trie.
+#[derive(Clone, Debug)]
+pub struct StorageMultiProof {
+    /// Storage trie root.
+    pub root: B256,
+    /// Storage multiproof for requested slots.
+    pub subtree: ProofNodes,
+}
+
+impl Default for StorageMultiProof {
+    fn default() -> Self {
+        Self { root: EMPTY_ROOT_HASH, subtree: Default::default() }
+    }
+}
+
+impl StorageMultiProof {
+    /// Return storage proofs for the target storage slot (unhashed).
+    pub fn storage_proof(&self, slot: B256) -> Result<StorageProof, alloy_rlp::Error> {
+        let nibbles = Nibbles::unpack(keccak256(slot));
+
+        // Retrieve the storage proof.
+        let proof = self
+            .subtree
+            .matching_nodes_iter(&nibbles)
+            .sorted_by(|a, b| a.0.cmp(b.0))
+            .map(|(_, node)| node.clone())
+            .collect::<Vec<_>>();
+
+        // Inspect the last node in the proof. If it's a leaf node with matching suffix,
+        // then the node contains the encoded slot value.
+        let value = 'value: {
+            if let Some(last) = proof.last() {
+                if let TrieNode::Leaf(leaf) = TrieNode::decode(&mut &last[..])? {
+                    if nibbles.ends_with(&leaf.key) {
+                        break 'value U256::decode(&mut &leaf.value[..])?
+                    }
+                }
+            }
+            U256::ZERO
+        };
+
+        Ok(StorageProof { key: slot, nibbles, value, proof })
+    }
+}
+
+/// The merkle proof with the relevant account info.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountProof {
+    /// The address associated with the account.
+    pub address: Address,
+    /// Account info.
+    pub info: Option<Account>,
+    /// Array of rlp-serialized merkle trie nodes which starting from the root node and
+    /// following the path of the hashed address as key.
+    pub proof: Vec<Bytes>,
+    /// The storage trie root.
+    pub storage_root: B256,
+    /// Array of storage proofs as requested.
+    pub storage_proofs: Vec<StorageProof>,
+}
+
+impl Default for AccountProof {
+    fn default() -> Self {
+        Self::new(Address::default())
+    }
+}
+
+impl AccountProof {
+    /// Create new account proof entity.
+    pub const fn new(address: Address) -> Self {
+        Self {
+            address,
+            info: None,
+            proof: Vec::new(),
+            storage_root: EMPTY_ROOT_HASH,
+            storage_proofs: Vec::new(),
+        }
+    }
+
+    /// Verify the storage proofs and account proof against the provided state root.
+    pub fn verify(&self, root: B256) -> Result<(), ProofVerificationError> {
+        // Verify storage proofs.
+        for storage_proof in &self.storage_proofs {
+            storage_proof.verify(self.storage_root)?;
+        }
+
+        // Verify the account proof.
+        let expected = if self.info.is_none() && self.storage_root == EMPTY_ROOT_HASH {
+            None
+        } else {
+            Some(alloy_rlp::encode(TrieAccount::from((
+                self.info.unwrap_or_default(),
+                self.storage_root,
+            ))))
+        };
+        let nibbles = Nibbles::unpack(keccak256(self.address));
+        verify_proof(root, nibbles, expected, &self.proof)
+    }
+}
+
+/// The merkle proof of the storage entry.
+#[derive(Clone, PartialEq, Eq, Default, Debug, Serialize, Deserialize)]
+pub struct StorageProof {
+    /// The raw storage key.
+    pub key: B256,
+    /// The hashed storage key nibbles.
+    pub nibbles: Nibbles,
+    /// The storage value.
+    pub value: U256,
+    /// Array of rlp-serialized merkle trie nodes which starting from the storage root node and
+    /// following the path of the hashed storage slot as key.
+    pub proof: Vec<Bytes>,
+}
+
+impl StorageProof {
+    /// Create new storage proof from the storage slot.
+    pub fn new(key: B256) -> Self {
+        let nibbles = Nibbles::unpack(keccak256(key));
+        Self { key, nibbles, ..Default::default() }
+    }
+
+    /// Create new storage proof from the storage slot and its pre-hashed image.
+    pub fn new_with_hashed(key: B256, hashed_key: B256) -> Self {
+        Self { key, nibbles: Nibbles::unpack(hashed_key), ..Default::default() }
+    }
+
+    /// Create new storage proof from the storage slot and its pre-hashed image.
+    pub fn new_with_nibbles(key: B256, nibbles: Nibbles) -> Self {
+        Self { key, nibbles, ..Default::default() }
+    }
+
+    /// Verify the proof against the provided storage root.
+    pub fn verify(&self, root: B256) -> Result<(), ProofVerificationError> {
+        let expected =
+            if self.value.is_zero() { None } else { Some(encode_fixed_size(&self.value).to_vec()) };
+        verify_proof(root, self.nibbles.clone(), expected, &self.proof)
+    }
+}
+
+/// Implementation of hasher using our keccak256 hashing function
+/// for compatibility with `triehash` crate.
+#[cfg(any(test, feature = "test-utils"))]
+pub mod triehash {
+    use alloy_primitives::{keccak256, B256};
+    use hash_db::Hasher;
+    use plain_hasher::PlainHasher;
+
+    /// A [Hasher] that calculates a keccak256 hash of the given data.
+    #[derive(Default, Debug, Clone, PartialEq, Eq)]
+    #[non_exhaustive]
+    pub struct KeccakHasher;
+
+    #[cfg(any(test, feature = "test-utils"))]
+    impl Hasher for KeccakHasher {
+        type Out = B256;
+        type StdHasher = PlainHasher;
+
+        const LENGTH: usize = 32;
+
+        fn hash(x: &[u8]) -> Self::Out {
+            keccak256(x)
+        }
+    }
+}
+

--- a/src/root.rs
+++ b/src/root.rs
@@ -1,0 +1,123 @@
+//! Common root computation functions.
+
+use crate::{HashBuilder, TrieAccount};
+use alloy_consensus::EMPTY_ROOT_HASH;
+use alloy_primitives::{keccak256, Address, B256, U256};
+use alloy_rlp::Encodable;
+use itertools::Itertools;
+use nybbles::Nibbles;
+
+/// Adjust the index of an item for rlp encoding.
+pub const fn adjust_index_for_rlp(i: usize, len: usize) -> usize {
+    if i > 0x7f {
+        i
+    } else if i == 0x7f || i + 1 == len {
+        0
+    } else {
+        i + 1
+    }
+}
+
+/// Compute a trie root of the collection of rlp encodable items.
+pub fn ordered_trie_root<T: Encodable>(items: &[T]) -> B256 {
+    ordered_trie_root_with_encoder(items, |item, buf| item.encode(buf))
+}
+
+/// Compute a trie root of the collection of items with a custom encoder.
+pub fn ordered_trie_root_with_encoder<T, F>(items: &[T], mut encode: F) -> B256
+where
+    F: FnMut(&T, &mut Vec<u8>),
+{
+    if items.is_empty() {
+        return EMPTY_ROOT_HASH;
+    }
+
+    let mut value_buffer = Vec::new();
+
+    let mut hb = HashBuilder::default();
+    let items_len = items.len();
+    for i in 0..items_len {
+        let index = adjust_index_for_rlp(i, items_len);
+
+        let index_buffer = alloy_rlp::encode_fixed_size(&index);
+
+        value_buffer.clear();
+        encode(&items[index], &mut value_buffer);
+
+        hb.add_leaf(Nibbles::unpack(&index_buffer), &value_buffer);
+    }
+
+    hb.root()
+}
+
+/// Hashes and sorts account keys, then proceeds to calculating the root hash of the state
+/// represented as MPT.
+/// See [`state_root_unsorted`] for more info.
+pub fn state_root_ref_unhashed<'a, A: Into<TrieAccount> + Clone + 'a>(
+    state: impl IntoIterator<Item = (&'a Address, &'a A)>,
+) -> B256 {
+    state_root_unsorted(
+        state.into_iter().map(|(address, account)| (keccak256(address), account.clone())),
+    )
+}
+
+/// Hashes and sorts account keys, then proceeds to calculating the root hash of the state
+/// represented as MPT.
+/// See [`state_root_unsorted`] for more info.
+pub fn state_root_unhashed<A: Into<TrieAccount>>(
+    state: impl IntoIterator<Item = (Address, A)>,
+) -> B256 {
+    state_root_unsorted(state.into_iter().map(|(address, account)| (keccak256(address), account)))
+}
+
+/// Sorts the hashed account keys and calculates the root hash of the state represented as MPT.
+/// See [`state_root`] for more info.
+pub fn state_root_unsorted<A: Into<TrieAccount>>(
+    state: impl IntoIterator<Item = (B256, A)>,
+) -> B256 {
+    state_root(state.into_iter().sorted_unstable_by_key(|(key, _)| *key))
+}
+
+/// Calculates the root hash of the state represented as MPT.
+///
+/// Corresponds to [geth's `deriveHash`](https://github.com/ethereum/go-ethereum/blob/6c149fd4ad063f7c24d726a73bc0546badd1bc73/core/genesis.go#L119).
+///
+/// # Panics
+///
+/// If the items are not in sorted order.
+pub fn state_root<A: Into<TrieAccount>>(state: impl IntoIterator<Item = (B256, A)>) -> B256 {
+    let mut hb = HashBuilder::default();
+    let mut account_rlp_buf = Vec::new();
+    for (hashed_key, account) in state {
+        account_rlp_buf.clear();
+        account.into().encode(&mut account_rlp_buf);
+        hb.add_leaf(Nibbles::unpack(hashed_key), &account_rlp_buf);
+    }
+    hb.root()
+}
+
+/// Hashes storage keys, sorts them and them calculates the root hash of the storage trie.
+/// See [`storage_root_unsorted`] for more info.
+pub fn storage_root_unhashed(storage: impl IntoIterator<Item = (B256, U256)>) -> B256 {
+    storage_root_unsorted(storage.into_iter().map(|(slot, value)| (keccak256(slot), value)))
+}
+
+/// Sorts and calculates the root hash of account storage trie.
+/// See [`storage_root`] for more info.
+pub fn storage_root_unsorted(storage: impl IntoIterator<Item = (B256, U256)>) -> B256 {
+    storage_root(storage.into_iter().sorted_unstable_by_key(|(key, _)| *key))
+}
+
+/// Calculates the root hash of account storage trie.
+///
+/// # Panics
+///
+/// If the items are not in sorted order.
+pub fn storage_root(storage: impl IntoIterator<Item = (B256, U256)>) -> B256 {
+    let mut hb = HashBuilder::default();
+    for (hashed_slot, value) in storage {
+        hb.add_leaf(Nibbles::unpack(hashed_slot), alloy_rlp::encode_fixed_size(&value).as_ref());
+    }
+    hb.root()
+}
+

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,108 @@
+use bytes::Buf;
+use reth_codecs::Compact;
+use revm_primitives::B256;
+use serde::{Deserialize, Serialize};
+
+use crate::{BranchNodeCompact, StoredNibblesSubKey, TrieMask};
+
+/// Account storage trie node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
+pub struct StorageTrieEntry {
+    /// The nibbles of the intermediate node
+    pub nibbles: StoredNibblesSubKey,
+    /// Encoded node.
+    pub node: BranchNodeCompact,
+}
+
+impl Compact for TrieMask {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        buf.put_u16(self.get());
+        2
+    }
+
+    fn from_compact(mut buf: &[u8], _len: usize) -> (Self, &[u8]) {
+        let mask = buf.get_u16();
+        (Self::new(mask), buf)
+    }
+}
+
+
+impl Compact for BranchNodeCompact {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let mut buf_size = 0;
+
+        buf_size += self.state_mask.to_compact(buf);
+        buf_size += self.tree_mask.to_compact(buf);
+        buf_size += self.hash_mask.to_compact(buf);
+
+        if let Some(root_hash) = self.root_hash {
+            buf_size += B256::len_bytes();
+            buf.put_slice(root_hash.as_slice());
+        }
+
+        for hash in &self.hashes {
+            buf_size += B256::len_bytes();
+            buf.put_slice(hash.as_slice());
+        }
+
+        buf_size
+    }
+
+    fn from_compact(buf: &[u8], _len: usize) -> (Self, &[u8]) {
+        let hash_len = B256::len_bytes();
+
+        // Assert the buffer is long enough to contain the masks and the hashes.
+        assert_eq!(buf.len() % hash_len, 6);
+
+        // Consume the masks.
+        let (state_mask, buf) = TrieMask::from_compact(buf, 0);
+        let (tree_mask, buf) = TrieMask::from_compact(buf, 0);
+        let (hash_mask, buf) = TrieMask::from_compact(buf, 0);
+
+        let mut buf = buf;
+        let mut num_hashes = buf.len() / hash_len;
+        let mut root_hash = None;
+
+        // Check if the root hash is present
+        if hash_mask.count_ones() as usize + 1 == num_hashes {
+            root_hash = Some(B256::from_slice(&buf[..hash_len]));
+            buf.advance(hash_len);
+            num_hashes -= 1;
+        }
+
+        // Consume all remaining hashes.
+        let mut hashes = Vec::<B256>::with_capacity(num_hashes);
+        for _ in 0..num_hashes {
+            hashes.push(B256::from_slice(&buf[..hash_len]));
+            buf.advance(hash_len);
+        }
+
+        (Self::new(state_mask, tree_mask, hash_mask, hashes, root_hash), buf)
+    }
+}
+
+
+impl Compact for StorageTrieEntry {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let nibbles_len = self.nibbles.to_compact(buf);
+        let node_len = self.node.to_compact(buf);
+        nibbles_len + node_len
+    }
+
+    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+        let (nibbles, buf) = StoredNibblesSubKey::from_compact(buf, 33);
+        let (node, buf) = BranchNodeCompact::from_compact(buf, len - 33);
+        let this = Self { nibbles, node };
+        (this, buf)
+    }
+}
+

--- a/src/subnode.rs
+++ b/src/subnode.rs
@@ -1,0 +1,97 @@
+use bytes::Buf;
+use reth_codecs::Compact;
+
+use crate::BranchNodeCompact;
+
+/// Walker sub node for storing intermediate state root calculation state in the database.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct StoredSubNode {
+    /// The key of the current node.
+    pub key: Vec<u8>,
+    /// The index of the next child to visit.
+    pub nibble: Option<u8>,
+    /// The node itself.
+    pub node: Option<BranchNodeCompact>,
+}
+
+impl Compact for StoredSubNode {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let mut len = 0;
+
+        buf.put_u16(self.key.len() as u16);
+        buf.put_slice(&self.key[..]);
+        len += 2 + self.key.len();
+
+        if let Some(nibble) = self.nibble {
+            buf.put_u8(1);
+            buf.put_u8(nibble);
+            len += 2;
+        } else {
+            buf.put_u8(0);
+            len += 1;
+        }
+
+        if let Some(node) = &self.node {
+            buf.put_u8(1);
+            len += 1;
+            len += node.to_compact(buf);
+        } else {
+            len += 1;
+            buf.put_u8(0);
+        }
+
+        len
+    }
+
+    fn from_compact(mut buf: &[u8], _len: usize) -> (Self, &[u8]) {
+        let key_len = buf.get_u16() as usize;
+        let key = Vec::from(&buf[..key_len]);
+        buf.advance(key_len);
+
+        let nibbles_exists = buf.get_u8() != 0;
+        let nibble = if nibbles_exists { Some(buf.get_u8()) } else { None };
+
+        let node_exists = buf.get_u8() != 0;
+        let node = if node_exists {
+            let (node, rest) = BranchNodeCompact::from_compact(buf, 0);
+            buf = rest;
+            Some(node)
+        } else {
+            None
+        };
+
+        (Self { key, nibble, node }, buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TrieMask;
+    use alloy_primitives::B256;
+
+    #[test]
+    fn subnode_roundtrip() {
+        let subnode = StoredSubNode {
+            key: vec![],
+            nibble: None,
+            node: Some(BranchNodeCompact {
+                state_mask: TrieMask::new(1),
+                tree_mask: TrieMask::new(0),
+                hash_mask: TrieMask::new(1),
+                hashes: vec![B256::ZERO],
+                root_hash: None,
+            }),
+        };
+
+        let mut encoded = vec![];
+        subnode.to_compact(&mut encoded);
+        let (decoded, _) = StoredSubNode::from_compact(&encoded[..], 0);
+
+        assert_eq!(subnode, decoded);
+    }
+}
+


### PR DESCRIPTION
## Description
This PR moves all the code from reth/crates/trie/common/ (not just the trie root logic) to alloy-trie, as discussed in [issue #11211](https://github.com/paradigmxyz/reth/issues/11211). The idea is to have all the trie-related functionality in one place within the alloy-trie crate.

The project compiles smoothly with the reth crate added in Cargo.toml, and I haven't run into any circular dependency issues. That said, I want to ensure this aligns with the direction you're heading.

## Question
Does this approach fit with what you have in mind? Also, is the plan for reth to start using all this functionality from alloy-trie moving forward?