### PR TITLE
chore(hash-builder): use `RlpNode::as_hash`

### DIFF
--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -170,8 +170,8 @@ impl HashBuilder {
 
     fn current_root(&self) -> B256 {
         if let Some(node_ref) = self.stack.last() {
-            if node_ref.len() == B256::len_bytes() + 1 {
-                B256::from_slice(&node_ref[1..])
+            if let Some(hash) = node_ref.as_hash() {
+                hash
             } else {
                 keccak256(node_ref)
             }


### PR DESCRIPTION
Ref https://github.com/alloy-rs/trie/pull/57