### PR TITLE
fix: create intermediate nodes when needed

### DIFF
--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -668,7 +668,7 @@ mod tests {
 
         let deep_key = Nibbles::from_nibbles_unchecked(vec![0, 1, 2, 3]);
 
-        let value = alloy_rlp::encode(&U256::from(42)).to_vec();
+        let value = alloy_rlp::encode(U256::from(42)).to_vec();
         hb.add_leaf(deep_key.clone(), &value);
 
         // calculate root to ensure all nodes are created
@@ -721,7 +721,7 @@ mod tests {
         let key1 = Nibbles::from_nibbles_unchecked(vec![1, 2, 3]);
         let key2 = Nibbles::from_nibbles_unchecked(vec![1, 2, 4]);
 
-        let value = alloy_rlp::encode(&U256::from(42)).to_vec();
+        let value = alloy_rlp::encode(U256::from(42)).to_vec();
         hb.add_leaf(key1, &value);
         hb.add_leaf(key2, &value);
 

--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -479,7 +479,7 @@ mod tests {
     use super::*;
     use crate::{nodes::LeafNode, triehash_trie_root};
     use alloc::collections::BTreeMap;
-    use alloy_primitives::{b256, hex, map::HashSet, U256};
+    use alloy_primitives::{b256, hex, U256};
     use alloy_rlp::Encodable;
 
     // Hashes the keys, RLP encodes the values, compares the trie builder with the upstream root.
@@ -872,10 +872,7 @@ mod tests {
         assert_eq!(root, triehash_trie_root(data));
     }
 
-    fn verify_tree_mask_invariant(
-        nodes: &HashMap<Nibbles, BranchNodeCompact>,
-        removed: &HashSet<Nibbles>,
-    ) -> bool {
+    fn verify_tree_mask_invariant(nodes: &HashMap<Nibbles, BranchNodeCompact>) -> bool {
         for (path, branch_node) in nodes {
             let child_paths = (0..16)
                 .filter(|&pos| (branch_node.tree_mask.get() & (1 << pos)) != 0)
@@ -887,7 +884,7 @@ mod tests {
                 .collect::<Vec<_>>();
 
             for child_path in child_paths {
-                if !nodes.contains_key(&child_path) && !removed.contains(&child_path) {
+                if !nodes.contains_key(&child_path) {
                     return false;
                 }
             }
@@ -933,6 +930,6 @@ mod tests {
             );
         }
 
-        assert!(verify_tree_mask_invariant(&updates, &HashSet::new()));
+        assert!(verify_tree_mask_invariant(&updates));
     }
 }

--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -479,9 +479,8 @@ mod tests {
     use super::*;
     use crate::{nodes::LeafNode, triehash_trie_root};
     use alloc::collections::BTreeMap;
-    use alloy_primitives::{b256, hex, U256};
+    use alloy_primitives::{b256, hex, map::HashSet, U256};
     use alloy_rlp::Encodable;
-    use std::collections::HashSet;
 
     // Hashes the keys, RLP encodes the values, compares the trie builder with the upstream root.
     fn assert_hashed_trie_root<'a, I, K>(iter: I)
@@ -889,12 +888,6 @@ mod tests {
 
             for child_path in child_paths {
                 if !nodes.contains_key(&child_path) && !removed.contains(&child_path) {
-                    println!(
-                        "Missing child node at path: {:?} for parent: {:?} with mask: {:016b}",
-                        child_path,
-                        path,
-                        branch_node.tree_mask.get()
-                    );
                     return false;
                 }
             }


### PR DESCRIPTION
Towards: https://github.com/paradigmxyz/reth/issues/12129

* Fixed intermediate node creation: create nodes with the appropriate tree mask and state mask when the current path is more than 1 nibble longer than the current prefix. As the tests here showed https://github.com/paradigmxyz/reth/pull/12080, we had issues with a path like `0b060502`, the node at `0b` has tree mask `0000000001000000` (expects child at position 6), there is no node at `0b06` but there is a node at `0b0605`. These changes fix the creation of the missing intermediate node. 
* Added unit tests for new functionality, specifically for intermediate node creation with different setups and verification of tree mask is a subset of state mask
* Added unit test to cover https://github.com/paradigmxyz/reth/issues/12129 with data from the case described above.