### PR TITLE
feat: `HashBuilder::add_leaf_unchecked`

### DIFF
--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -110,8 +110,21 @@ impl HashBuilder {
     }
 
     /// Adds a new leaf element and its value to the trie hash builder.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new key does not come after the current key.
     pub fn add_leaf(&mut self, key: Nibbles, value: &[u8]) {
         assert!(key > self.key, "add_leaf key {:?} self.key {:?}", key, self.key);
+        self.add_leaf_unchecked(key, value);
+    }
+
+    /// Adds a new leaf element and its value to the trie hash builder,
+    /// without checking the order of the new key. This is only for
+    /// performance-critical usage that guarantees keys are inserted
+    /// in sorted order.
+    pub fn add_leaf_unchecked(&mut self, key: Nibbles, value: &[u8]) {
+        debug_assert!(key > self.key, "add_leaf_unchecked key {:?} self.key {:?}", key, self.key);
         if !self.key.is_empty() {
             self.update(&key);
         }


### PR DESCRIPTION
We're stress-testing live state root calculation in Reth that led back to this crate (thanks for the great work!).

So, this `assert` takes ~7.7% of `HashBuilder::add_leaf` and ~1% of `StateRoot::calculate`:
https://github.com/alloy-rs/trie/blob/25c252f6dab144a1509b223a54add7b17cba8f7d/src/hash_builder/mod.rs#L113-L114

<img width="664" alt="image" src="https://github.com/user-attachments/assets/d1b77aad-8312-41a6-bee3-1d2d31eacf53">

This PR adds an `unchecked` version for performance-critical users who guarantee keys are added in sorted order (like Reth with its node iterator).