### PR TITLE
feat: retain hash masks of branch nodes

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,7 +23,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
-    "Unicode-DFS-2016",
+    "Unicode-3",
     "Unlicense",
     "MPL-2.0",
     "Zlib",

--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -158,7 +158,7 @@ impl HashBuilder {
         let root = self.current_root();
         if root == EMPTY_ROOT_HASH {
             if let Some(proof_retainer) = self.proof_retainer.as_mut() {
-                proof_retainer.retain(&Nibbles::default(), &[EMPTY_STRING_CODE], None)
+                proof_retainer.retain(&Nibbles::default(), &[EMPTY_STRING_CODE])
             }
         }
         root
@@ -267,7 +267,7 @@ impl HashBuilder {
                             "pushing leaf node",
                         );
                         self.stack.push(rlp);
-                        self.retain_proof_from_buf(&current.slice(..len_from), None);
+                        self.retain_proof_from_buf(&current.slice(..len_from));
                     }
                     HashBuilderValueRef::Hash(hash) => {
                         trace!(target: "trie::hash_builder", ?hash, "pushing branch node hash");
@@ -299,7 +299,7 @@ impl HashBuilder {
                     "pushing extension node",
                 );
                 self.stack.push(rlp);
-                self.retain_proof_from_buf(&current.slice(..len_from), None);
+                self.retain_proof_from_buf(&current.slice(..len_from));
                 self.resize_masks(len_from);
             }
 
@@ -357,7 +357,7 @@ impl HashBuilder {
 
         self.rlp_buf.clear();
         let rlp = branch_node.rlp(&mut self.rlp_buf);
-        self.retain_proof_from_buf(&current.slice(..len), Some(hash_mask));
+        self.retain_proof_from_buf_with_hash_mask(&current.slice(..len), hash_mask);
 
         // Clears the stack from the branch node elements
         let first_child_idx = self.stack.len() - state_mask.count_ones() as usize;
@@ -406,9 +406,15 @@ impl HashBuilder {
         }
     }
 
-    fn retain_proof_from_buf(&mut self, prefix: &Nibbles, hash_mask: Option<TrieMask>) {
+    fn retain_proof_from_buf(&mut self, prefix: &Nibbles) {
         if let Some(proof_retainer) = self.proof_retainer.as_mut() {
-            proof_retainer.retain(prefix, &self.rlp_buf, hash_mask)
+            proof_retainer.retain(prefix, &self.rlp_buf)
+        }
+    }
+
+    fn retain_proof_from_buf_with_hash_mask(&mut self, prefix: &Nibbles, hash_mask: TrieMask) {
+        if let Some(proof_retainer) = self.proof_retainer.as_mut() {
+            proof_retainer.retain_with_hash_mask(prefix, &self.rlp_buf, hash_mask);
         }
     }
 

--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::{
     nodes::RlpNode,
-    proof::{HashMasks, ProofNodes},
+    proof::{BranchNodeHashMasks, ProofNodes},
     HashMap,
 };
 use alloc::vec::Vec;
@@ -92,9 +92,17 @@ impl HashBuilder {
         (self, updates.unwrap_or_default())
     }
 
-    /// Take and return retained proof nodes along with hash masks of retained branch nodes.
-    pub fn take_proof_nodes(&mut self) -> (ProofNodes, HashMasks) {
+    /// Take and return retained proof nodes.
+    pub fn take_proof_nodes(&mut self) -> ProofNodes {
         self.proof_retainer.take().map(ProofRetainer::into_proof_nodes).unwrap_or_default()
+    }
+
+    /// Take and return retained proof nodes along with hash masks of retained branch nodes.
+    pub fn take_proof_nodes_with_hash_masks(&mut self) -> (ProofNodes, BranchNodeHashMasks) {
+        self.proof_retainer
+            .take()
+            .map(ProofRetainer::into_proof_nodes_with_hash_masks)
+            .unwrap_or_default()
     }
 
     /// The number of total updates accrued.

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -13,4 +13,4 @@ mod proof_nodes;
 pub use proof_nodes::ProofNodes;
 
 mod retainer;
-pub use retainer::ProofRetainer;
+pub use retainer::{HashMasks, ProofRetainer};

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -13,4 +13,4 @@ mod proof_nodes;
 pub use proof_nodes::ProofNodes;
 
 mod retainer;
-pub use retainer::{HashMasks, ProofRetainer};
+pub use retainer::{BranchNodeHashMasks, ProofRetainer};

--- a/src/proof/retainer.rs
+++ b/src/proof/retainer.rs
@@ -13,11 +13,11 @@ pub struct ProofRetainer {
     /// Map of retained trie node paths to RLP serialized trie nodes.
     proof_nodes: ProofNodes,
     /// Map of retained branch node paths to hash masks.
-    hash_masks: HashMasks,
+    hash_masks: BranchNodeHashMasks,
 }
 
 /// Map of retained branch node paths to hash masks.
-pub type HashMasks = HashMap<Nibbles, TrieMask>;
+pub type BranchNodeHashMasks = HashMap<Nibbles, TrieMask>;
 
 impl FromIterator<Nibbles> for ProofRetainer {
     fn from_iter<T: IntoIterator<Item = Nibbles>>(iter: T) -> Self {
@@ -36,8 +36,13 @@ impl ProofRetainer {
         self.targets.iter().any(|target| target.starts_with(prefix))
     }
 
+    /// Returns all collected proofs.
+    pub fn into_proof_nodes(self) -> ProofNodes {
+        self.proof_nodes
+    }
+
     /// Returns all collected proofs and hash masks of retained branch nodes.
-    pub fn into_proof_nodes(self) -> (ProofNodes, HashMasks) {
+    pub fn into_proof_nodes_with_hash_masks(self) -> (ProofNodes, BranchNodeHashMasks) {
         (self.proof_nodes, self.hash_masks)
     }
 

--- a/src/proof/retainer.rs
+++ b/src/proof/retainer.rs
@@ -1,5 +1,5 @@
-use crate::{proof::ProofNodes, Nibbles};
-use alloy_primitives::Bytes;
+use crate::{proof::ProofNodes, Nibbles, TrieMask};
+use alloy_primitives::{map::HashMap, Bytes};
 
 #[allow(unused_imports)]
 use alloc::vec::Vec;
@@ -8,11 +8,16 @@ use alloc::vec::Vec;
 /// It is intended to be used within the [`HashBuilder`](crate::HashBuilder).
 #[derive(Default, Debug)]
 pub struct ProofRetainer {
-    /// The nibbles of the target trie keys to retain proofs for.
+    /// Nibbles of the target trie paths to retain proofs for.
     targets: Vec<Nibbles>,
-    /// The map retained trie node keys to RLP serialized trie nodes.
+    /// Map of retained trie node paths to RLP serialized trie nodes.
     proof_nodes: ProofNodes,
+    /// Map of retained branch node paths to hash masks.
+    hash_masks: HashMasks,
 }
+
+/// Map of retained branch node paths to hash masks.
+pub type HashMasks = HashMap<Nibbles, TrieMask>;
 
 impl FromIterator<Nibbles> for ProofRetainer {
     fn from_iter<T: IntoIterator<Item = Nibbles>>(iter: T) -> Self {
@@ -23,7 +28,7 @@ impl FromIterator<Nibbles> for ProofRetainer {
 impl ProofRetainer {
     /// Create new retainer with target nibbles.
     pub fn new(targets: Vec<Nibbles>) -> Self {
-        Self { targets, proof_nodes: Default::default() }
+        Self { targets, ..Default::default() }
     }
 
     /// Returns `true` if the given prefix matches the retainer target.
@@ -31,15 +36,18 @@ impl ProofRetainer {
         self.targets.iter().any(|target| target.starts_with(prefix))
     }
 
-    /// Returns all collected proofs.
-    pub fn into_proof_nodes(self) -> ProofNodes {
-        self.proof_nodes
+    /// Returns all collected proofs and hash masks of retained branch nodes.
+    pub fn into_proof_nodes(self) -> (ProofNodes, HashMasks) {
+        (self.proof_nodes, self.hash_masks)
     }
 
     /// Retain the proof if the key matches any of the targets.
-    pub fn retain(&mut self, prefix: &Nibbles, proof: &[u8]) {
+    pub fn retain(&mut self, prefix: &Nibbles, proof: &[u8], hash_mask: Option<TrieMask>) {
         if prefix.is_empty() || self.matches(prefix) {
             self.proof_nodes.insert(prefix.clone(), Bytes::from(proof.to_vec()));
+            if let Some(hash_mask) = hash_mask {
+                self.hash_masks.insert(prefix.clone(), hash_mask);
+            }
         }
     }
 }

--- a/src/proof/retainer.rs
+++ b/src/proof/retainer.rs
@@ -47,12 +47,17 @@ impl ProofRetainer {
     }
 
     /// Retain the proof if the key matches any of the targets.
-    pub fn retain(&mut self, prefix: &Nibbles, proof: &[u8], hash_mask: Option<TrieMask>) {
+    pub fn retain(&mut self, prefix: &Nibbles, proof: &[u8]) {
         if prefix.is_empty() || self.matches(prefix) {
             self.proof_nodes.insert(prefix.clone(), Bytes::from(proof.to_vec()));
-            if let Some(hash_mask) = hash_mask {
-                self.hash_masks.insert(prefix.clone(), hash_mask);
-            }
+        }
+    }
+
+    /// Retain the proof and the branch node hash mask if the key matches any of the targets.
+    pub fn retain_with_hash_mask(&mut self, prefix: &Nibbles, proof: &[u8], hash_mask: TrieMask) {
+        if prefix.is_empty() || self.matches(prefix) {
+            self.proof_nodes.insert(prefix.clone(), Bytes::from(proof.to_vec()));
+            self.hash_masks.insert(prefix.clone(), hash_mask);
         }
     }
 }


### PR DESCRIPTION
We need to retain hash masks of the retained branch nodes to be able to emit correct [`TrieUpdates`](https://github.com/paradigmxyz/reth/blob/025885f2ad3fb881b1d2180e1998797f0b968b88/crates/trie/common/src/updates.rs#L7-L19) from the [Sparse Trie](https://github.com/paradigmxyz/reth/blob/025885f2ad3fb881b1d2180e1998797f0b968b88/crates/trie/sparse/src/trie.rs)