### PR TITLE
perf: bump and use nybbles 0.3.3 raw APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ derive_more = { version = "1", default-features = false, features = [
     "from",
     "not",
 ] }
-nybbles = { version = "0.3", default-features = false }
+nybbles = { version = "0.3.3", default-features = false }
 smallvec = { version = "1.0", default-features = false, features = [
     "const_new",
 ] }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -17,8 +17,8 @@ pub fn nibbles_path_encoding(c: &mut Criterion) {
         g.throughput(criterion::Throughput::Bytes(len));
         let id = criterion::BenchmarkId::new("trie", len);
         g.bench_function(id, |b| {
-            let nibbles = get_nibbles(len as usize);
-            b.iter(|| black_box(encode_path_leaf(&nibbles, false)))
+            let nibbles = &get_nibbles(len as usize);
+            b.iter(|| encode_path_leaf(black_box(nibbles), false))
         });
     }
 }


### PR DESCRIPTION
```julia
encode_path_leaf/trie/16                                                                             
                        time:   [7.4696 ns 7.5057 ns 7.5460 ns]
                        thrpt:  [1.9747 GiB/s 1.9853 GiB/s 1.9949 GiB/s]
                 change:
                        time:   [-54.320% -54.075% -53.843%] (p = 0.00 < 0.05)
                        thrpt:  [+116.65% +117.74% +118.91%]
                        Performance has improved.
encode_path_leaf/trie/32                                                                             
                        time:   [9.5450 ns 9.5557 ns 9.5677 ns]
                        thrpt:  [3.1149 GiB/s 3.1188 GiB/s 3.1223 GiB/s]
                 change:
                        time:   [-43.515% -43.420% -43.320%] (p = 0.00 < 0.05)
                        thrpt:  [+76.431% +76.741% +77.040%]
                        Performance has improved.
encode_path_leaf/trie/256                                                                             
                        time:   [13.966 ns 14.016 ns 14.067 ns]
                        thrpt:  [16.949 GiB/s 17.010 GiB/s 17.071 GiB/s]
                 change:
                        time:   [-49.944% -49.789% -49.617%] (p = 0.00 < 0.05)
                        thrpt:  [+98.479% +99.158% +99.775%]
                        Performance has improved.
encode_path_leaf/trie/2048                                                                             
                        time:   [24.598 ns 24.633 ns 24.684 ns]
                        thrpt:  [77.272 GiB/s 77.430 GiB/s 77.539 GiB/s]
                 change:
                        time:   [-33.461% -33.298% -33.100%] (p = 0.00 < 0.05)
                        thrpt:  [+49.478% +49.921% +50.288%]
                        Performance has improved
```