### PR TITLE
Expose Serde support for `ProofNodes` and `DecodedProofNodes`

### DIFF
--- a/src/nodes/branch.rs
+++ b/src/nodes/branch.rs
@@ -12,6 +12,7 @@ use alloc::vec::Vec;
 /// character and an additional slot for a value. We do exclude the node value since all paths have
 /// a fixed size.
 #[derive(PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BranchNode {
     /// The collection of RLP encoded children.
     pub stack: Vec<RlpNode>,

--- a/src/nodes/extension.rs
+++ b/src/nodes/extension.rs
@@ -16,6 +16,7 @@ use alloc::vec::Vec;
 /// with a single child into one node. This simplification reduces the space and computational
 /// complexity when performing operations on the trie.
 #[derive(PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtensionNode {
     /// The key for this extension node.
     pub key: Nibbles,

--- a/src/nodes/leaf.rs
+++ b/src/nodes/leaf.rs
@@ -14,6 +14,7 @@ use alloc::vec::Vec;
 /// data associated with the full key. When searching the trie for a specific key, reaching a leaf
 /// node means that the search has successfully found the value associated with that key.
 #[derive(PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LeafNode {
     /// The key for this leaf node.
     pub key: Nibbles,

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -26,6 +26,7 @@ pub const CHILD_INDEX_RANGE: Range<u8> = 0..16;
 
 /// Enum representing an MPT trie node.
 #[derive(PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TrieNode {
     /// Variant representing empty root node.
     EmptyRoot,

--- a/src/proof/decoded_proof_nodes.rs
+++ b/src/proof/decoded_proof_nodes.rs
@@ -7,6 +7,7 @@ use alloc::vec::Vec;
 
 /// A wrapper struct for trie node key to RLP encoded trie node.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DecodedProofNodes(HashMap<Nibbles, TrieNode>);
 
 impl Deref for DecodedProofNodes {

--- a/src/proof/proof_nodes.rs
+++ b/src/proof/proof_nodes.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 
 /// A wrapper struct for trie node key to RLP encoded trie node.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProofNodes(HashMap<Nibbles, Bytes>);
 
 impl Deref for ProofNodes {


### PR DESCRIPTION
Intends to close: #79 