### PR TITLE
chore: rename groups to state_masks in hash builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ all = "warn"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }
-missing-const-for-fn = "warn"
+missing-const-for-fn = "allow" # TODO: https://github.com/rust-lang/rust-clippy/issues/14020
 use-self = "warn"
 redundant-clone = "warn"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
     missing_debug_implementations,
     missing_docs,
     unreachable_pub,
-    clippy::missing_const_for_fn,
     rustdoc::all
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]


### PR DESCRIPTION
`groups` naming is inconsistent with `state_masks` that we have everywhere else