### PR TITLE
ci: remove concurrency from bench

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,8 +2,6 @@
 
 on:
   pull_request:
-  # TODO: Disabled temporarily for https://github.com/CodSpeedHQ/runner/issues/55
-  # merge_group:
   push:
     branches: [main]
 
@@ -11,10 +9,6 @@ env:
   CARGO_TERM_COLOR: always
   BASELINE: base
   SEED: alloy-trie
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 
 name: bench
 jobs:


### PR DESCRIPTION
Codspeed handles runs per commit so we can allow concurrency.