### PR TITLE
Fix bug where tree_mask would get incorrectly set in certain cases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ hash-db = "0.15"
 plain_hasher = "0.2"
 triehash = "0.8.4"
 criterion = { version = "2.10", package = "codspeed-criterion-compat" }
+pretty_assertions = "1.4.1"
 
 [features]
 default = ["std", "alloy-primitives/default"]

--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -779,6 +779,8 @@ mod tests {
 
     #[test]
     fn test_updated_branches() {
+        use alloc::sync::Arc;
+
         struct TestCase<I, U, K>
         where
             I: IntoIterator<Item = K>,
@@ -805,7 +807,7 @@ mod tests {
                             state_mask: 0b1000010.into(),
                             hash_mask: 0b1000000.into(),
                             tree_mask: 0b1000000.into(),
-                            hashes: std::sync::Arc::new(vec![b256!(
+                            hashes: Arc::new(vec![b256!(
                                 "0x15838525b335e53d4e72bf39d3092bad7c71f6b6b8e8e043b8ee579feb40a006"
                             )]),
                             ..Default::default()
@@ -816,7 +818,7 @@ mod tests {
                         BranchNodeCompact {
                             state_mask: 0b101.into(),
                             hash_mask: 0b100.into(),
-                            hashes: std::sync::Arc::new(vec![b256!(
+                            hashes: Arc::new(vec![b256!(
                                 "0x6c51badda0fcff78960af0b926394e7d2c5990f9440a11bd9cdccb40386443f3"
                             )]),
                             ..Default::default()
@@ -844,7 +846,7 @@ mod tests {
                         BranchNodeCompact {
                             state_mask: 0b101.into(),
                             hash_mask: 0b100.into(),
-                            hashes: std::sync::Arc::new(vec![b256!(
+                            hashes: Arc::new(vec![b256!(
                                 "0x9c5edb7001f44e65e02aa6ff495dfd1a2805370a383974962522d55b2f13f4f1"
                             )]),
                             ..Default::default()
@@ -872,7 +874,7 @@ mod tests {
                             // because that key is an extension.
                             tree_mask: 0b1000.into(),
                             hash_mask: 0b1000.into(),
-                            hashes: std::sync::Arc::new(vec![b256!(
+                            hashes: Arc::new(vec![b256!(
                                 "0x4711fabfbb5e0a6649e7ba0cc245f7fa91dabf519834ad565caf750801fd6d9d"
                             )]),
                             ..Default::default()
@@ -883,7 +885,7 @@ mod tests {
                         BranchNodeCompact {
                             state_mask: 0b101.into(),
                             hash_mask: 0b1.into(),
-                            hashes: std::sync::Arc::new(vec![b256!(
+                            hashes: Arc::new(vec![b256!(
                                 "0xdbd62ee8064df09b1a2bc7145eca3e2567b8d010bbcd1aa81b1d38fea2032d34"
                             )]),
                             ..Default::default()
@@ -894,7 +896,7 @@ mod tests {
                         BranchNodeCompact {
                             state_mask: 0b101000.into(),
                             hash_mask: 0b1000.into(),
-                            hashes: std::sync::Arc::new(vec![b256!(
+                            hashes: Arc::new(vec![b256!(
                                 "0xa58cc5f13589f5f57e0aaf9b09e560f26f6bd81cf6ee3a979e2cb90cc90980c8"
                             )]),
                             ..Default::default()


### PR DESCRIPTION
Hello! I noted the following open bug in reth and decided to use the opportunity to get a better understanding for the codebase and related libraries:

https://github.com/paradigmxyz/reth/issues/12129 (related PR which provided a test case: https://github.com/paradigmxyz/reth/pull/12080)

Most of my understanding of the problem and solution is based on my reading of the reth and alloy codebases and other materials, so I could well have made some wrong assumptions or misunderstood some fundamental point. Sorry if that's the case, but please let me know!

------

As I dug into the issue I found that the source of the problem was in the HashBuilder here in the trie library. As described in the original bug/pr, in certain cases  the tree_mask would get a bit set on it even though the corresponding child wouldn't appear in the set of updated branch nodes. This was due to the bit getting incorrectly set for extension nodes which pointed to intermediate branch nodes.

For example, the following is a simplified reproduction case based on the one in the above PR. Given these leafs:

```
0xb000000000000000000000000000000000000000000000000000000000000000
0xb650000000000000000000000000000000000000000000000000000000000000
0xb652000000000000000000000000000000000000000000000000000000000000
0xb652c00000000000000000000000000000000000000000000000000000000000
```

The node `0xb6` is an extension node with short key `5` leading to the branch node `0xb65`, which does appear in the updated branch nodes result. The branch node at `0xb` was incorrectly getting the bit for child 6 set in its tree_masks, due to this code in the `update_masks` method:

https://github.com/alloy-rs/trie/blob/c69e9f507dd99e455c35474574e109b5270586ec/src/hash_builder/mod.rs#L434-L436

Unfortunately it was not enough to simply remove the offending line, as the tree_masks is getting used to determine if an updated branch node should be created at all, and so would cause the `0xb65` branch node to not be included in the updated branch nodes set.

https://github.com/alloy-rs/trie/blob/c69e9f507dd99e455c35474574e109b5270586ec/src/hash_builder/mod.rs#L401

My solution is to simply do a bitwise AND between the hash_mask and the tree_mask when creating the BranchNodeCompact. If I'm not mistaken the hash mask will be correctly set with a bit only for child branch nodes, regardless of if the node is an intermediate node, and so is always a superset of the desired tree_mask. If this isn't correct then another solution will need to be found.

I've included a bunch of extra tracing which I found helpful during debugging, as well as some test cases which check the solution. If any of these aren't up to coding guidelines or what-have-you I can of course change them.