### PR TITLE
feat: retain proofs of non-target nodes in certain edge-cases.

### DIFF
--- a/src/hash_builder/mod.rs
+++ b/src/hash_builder/mod.rs
@@ -3,9 +3,9 @@
 use super::{
     BranchNodeCompact, EMPTY_ROOT_HASH, Nibbles, TrieMask,
     nodes::{BranchNodeRef, ExtensionNodeRef, LeafNodeRef},
-    proof::{AddedRemovedKeys, EmptyAddedRemovedKeys, ProofNodes, ProofRetainer},
+    proof::{ProofNodes, ProofRetainer},
 };
-use crate::{HashMap, nodes::RlpNode};
+use crate::{HashMap, nodes::RlpNode, proof::AddedRemovedKeys};
 use alloc::vec::Vec;
 use alloy_primitives::{B256, keccak256};
 use core::cmp;
@@ -40,7 +40,7 @@ pub use value::{HashBuilderValue, HashBuilderValueRef};
 /// verifying Merkle proofs.
 #[derive(Debug, Clone)]
 #[allow(missing_docs)]
-pub struct HashBuilder<K = EmptyAddedRemovedKeys> {
+pub struct HashBuilder<K = AddedRemovedKeys> {
     pub key: Nibbles,
     pub value: HashBuilderValue,
     pub stack: Vec<RlpNode>,
@@ -107,7 +107,9 @@ impl<K> HashBuilder<K> {
             self.updated_branch_nodes = Some(HashMap::default());
         }
     }
+}
 
+impl<K: AsRef<AddedRemovedKeys>> HashBuilder<K> {
     /// Splits the [HashBuilder] into a [HashBuilder] and hash builder updates.
     pub fn split(mut self) -> (Self, HashMap<Nibbles, BranchNodeCompact>) {
         let updates = self.updated_branch_nodes.take();
@@ -134,9 +136,7 @@ impl<K> HashBuilder<K> {
         }
         println!("============ END STACK ===============");
     }
-}
 
-impl<K: AddedRemovedKeys> HashBuilder<K> {
     /// Adds a new leaf element and its value to the trie hash builder.
     ///
     /// # Panics

--- a/src/proof/added_removed_keys.rs
+++ b/src/proof/added_removed_keys.rs
@@ -6,16 +6,12 @@ use alloy_primitives::{B256, map::B256Set};
 /// Used by the [`crate::proof::ProofRetainer`] to determine which nodes may be ancestors of newly
 /// added or removed leaves. This information allows for generation of more complete proofs which
 /// include the nodes necessary for adding and removing leaves from the trie.
-///
-/// Note: Currently only removed keys are tracked. Added keys tracking is not yet implemented.
 #[derive(Debug, Default, Clone)]
 pub struct AddedRemovedKeys {
     /// Keys which are known to be removed from the trie.
     removed_keys: B256Set,
-    /// Keys which are known to be added to the trie.
+    /// Keys which are known to be newly added to the trie.
     added_keys: B256Set,
-    /// Assume that all keys have been added.
-    assume_added: bool,
 }
 
 impl AsRef<Self> for AddedRemovedKeys {
@@ -25,14 +21,6 @@ impl AsRef<Self> for AddedRemovedKeys {
 }
 
 impl AddedRemovedKeys {
-    /// Sets the `assume_added` flag, which can be used instead of `insert_added` if exact
-    /// additions aren't known and you want to optimistically collect all proofs which _might_ be
-    /// necessary.
-    pub fn with_assume_added(mut self, assume_added: bool) -> Self {
-        self.assume_added = assume_added;
-        self
-    }
-
     /// Sets the key as being a removed key. This removes the key from the `added_keys` set if it
     /// was previously inserted into it.
     pub fn insert_removed(&mut self, key: B256) {
@@ -59,16 +47,15 @@ impl AddedRemovedKeys {
 
     /// Returns true if the given key path is marked as added.
     pub fn is_added(&self, path: &B256) -> bool {
-        self.assume_added || self.added_keys.contains(path)
+        self.added_keys.contains(path)
     }
 
     /// Returns true if the given path prefix is the prefix of an added key.
     pub fn is_prefix_added(&self, prefix: &Nibbles) -> bool {
-        self.assume_added
-            || self.added_keys.iter().any(|key| {
-                let key_nibbles = Nibbles::unpack(key);
-                key_nibbles.starts_with(prefix)
-            })
+        self.added_keys.iter().any(|key| {
+            let key_nibbles = Nibbles::unpack(key);
+            key_nibbles.starts_with(prefix)
+        })
     }
 
     /// Returns a mask containing a bit set for each child of the branch which is a prefix of a

--- a/src/proof/added_removed_keys.rs
+++ b/src/proof/added_removed_keys.rs
@@ -1,35 +1,87 @@
 use crate::{Nibbles, TrieMask};
+use alloy_primitives::{B256, map::B256Set};
 
+/// Provides added and removed keys for an account or storage trie.
+///
 /// Used by the [`crate::proof::ProofRetainer`] to determine which nodes may be ancestors of newly
 /// added or removed leaves. This information allows for generation of more complete proofs which
 /// include the nodes necessary for adding and removing leaves from the trie.
-pub trait AddedRemovedKeys {
-    /// Returns true if the given path prefix is the prefix of an added key.
-    ///
-    /// True should be returned optimistically; if a prefix only has the possibility of being added
-    /// it is better to return true for it. This may result in more proofs than necessary being
-    /// returned, but that's better than a missing proof.
-    fn is_prefix_added(&self, prefix: &Nibbles) -> bool;
-
-    /// Returns a mask containing a bit set for each child of the branch which may be considered
-    /// removed.
-    ///
-    /// Bits should be set optimistically; if a child only has the possibility of being removed it
-    /// is better to return a bit for it. Extra bits on the mask may result in more proofs than
-    /// necessary being returned, but that's better than a missing proof.
-    fn get_removed_mask(&self, branch_path: &Nibbles) -> TrieMask;
+///
+/// Note: Currently only removed keys are tracked. Added keys tracking is not yet implemented.
+#[derive(Debug, Default, Clone)]
+pub struct AddedRemovedKeys {
+    /// Keys which are known to be removed from the trie.
+    removed_keys: B256Set,
+    /// Keys which are known to be added to the trie.
+    added_keys: B256Set,
+    /// Assume that all keys have been added.
+    assume_added: bool,
 }
 
-/// An implementation of [`AddedRemovedKeys`] which assumes no added or removed keys.
-#[derive(Debug, Copy, Clone, Default)]
-pub struct EmptyAddedRemovedKeys;
+impl AsRef<Self> for AddedRemovedKeys {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
 
-impl AddedRemovedKeys for EmptyAddedRemovedKeys {
-    fn is_prefix_added(&self, _prefix: &Nibbles) -> bool {
-        false
+impl AddedRemovedKeys {
+    /// Sets the `assume_added` flag, which can be used instead of `insert_added` if exact
+    /// additions aren't known and you want to optimistically collect all proofs which _might_ be
+    /// necessary.
+    pub fn with_assume_added(mut self, assume_added: bool) -> Self {
+        self.assume_added = assume_added;
+        self
     }
 
-    fn get_removed_mask(&self, _branch_path: &Nibbles) -> TrieMask {
-        TrieMask::default()
+    /// Sets the key as being a removed key. This removes the key from the `added_keys` set if it
+    /// was previously inserted into it.
+    pub fn insert_removed(&mut self, key: B256) {
+        self.added_keys.remove(&key);
+        self.removed_keys.insert(key);
+    }
+
+    /// Unsets the key as being a removed key.
+    pub fn remove_removed(&mut self, key: &B256) {
+        self.removed_keys.remove(key);
+    }
+
+    /// Sets the key as being an added key. This removes the key from the `removed_keys` set if it
+    /// was previously inserted into it.
+    pub fn insert_added(&mut self, key: B256) {
+        self.removed_keys.remove(&key);
+        self.added_keys.insert(key);
+    }
+
+    /// Returns true if the given key path is marked as removed.
+    pub fn is_removed(&self, path: &B256) -> bool {
+        self.removed_keys.contains(path)
+    }
+
+    /// Returns true if the given key path is marked as added.
+    pub fn is_added(&self, path: &B256) -> bool {
+        self.assume_added || self.added_keys.contains(path)
+    }
+
+    /// Returns true if the given path prefix is the prefix of an added key.
+    pub fn is_prefix_added(&self, prefix: &Nibbles) -> bool {
+        self.assume_added
+            || self.added_keys.iter().any(|key| {
+                let key_nibbles = Nibbles::unpack(key);
+                key_nibbles.starts_with(prefix)
+            })
+    }
+
+    /// Returns a mask containing a bit set for each child of the branch which is a prefix of a
+    /// removed leaf.
+    pub fn get_removed_mask(&self, branch_path: &Nibbles) -> TrieMask {
+        let mut mask = TrieMask::default();
+        for key in &self.removed_keys {
+            let key_nibbles = Nibbles::unpack(key);
+            if key_nibbles.starts_with(branch_path) {
+                let child_bit = key_nibbles.get_unchecked(branch_path.len());
+                mask.set_bit(child_bit);
+            }
+        }
+        mask
     }
 }

--- a/src/proof/added_removed_keys.rs
+++ b/src/proof/added_removed_keys.rs
@@ -1,0 +1,35 @@
+use crate::{Nibbles, TrieMask};
+
+/// Used by the [`crate::proof::ProofRetainer`] to determine which nodes may be ancestors of newly
+/// added or removed leaves. This information allows for generation of more complete proofs which
+/// include the nodes necessary for adding and removing leaves from the trie.
+pub trait AddedRemovedKeys {
+    /// Returns true if the given path prefix is the prefix of an added key.
+    ///
+    /// True should be returned optimistically; if a prefix only has the possibility of being added
+    /// it is better to return true for it. This may result in more proofs than necessary being
+    /// returned, but that's better than a missing proof.
+    fn is_prefix_added(&self, prefix: &Nibbles) -> bool;
+
+    /// Returns a mask containing a bit set for each child of the branch which may be considered
+    /// removed.
+    ///
+    /// Bits should be set optimistically; if a child only has the possibility of being removed it
+    /// is better to return a bit for it. Extra bits on the mask may result in more proofs than
+    /// necessary being returned, but that's better than a missing proof.
+    fn get_removed_mask(&self, branch_path: &Nibbles) -> TrieMask;
+}
+
+/// An implementation of [`AddedRemovedKeys`] which assumes no added or removed keys.
+#[derive(Debug, Copy, Clone, Default)]
+pub struct EmptyAddedRemovedKeys;
+
+impl AddedRemovedKeys for EmptyAddedRemovedKeys {
+    fn is_prefix_added(&self, _prefix: &Nibbles) -> bool {
+        false
+    }
+
+    fn get_removed_mask(&self, _branch_path: &Nibbles) -> TrieMask {
+        TrieMask::default()
+    }
+}

--- a/src/proof/added_removed_keys.rs
+++ b/src/proof/added_removed_keys.rs
@@ -52,6 +52,11 @@ impl AddedRemovedKeys {
         self.added_keys.insert(key);
     }
 
+    /// Clears all keys which have been added via `insert_added`.
+    pub fn clear_added(&mut self) {
+        self.added_keys.clear();
+    }
+
     /// Returns true if the given key path is marked as removed.
     pub fn is_removed(&self, path: &B256) -> bool {
         self.removed_keys.contains(path)

--- a/src/proof/added_removed_keys.rs
+++ b/src/proof/added_removed_keys.rs
@@ -6,12 +6,16 @@ use alloy_primitives::{B256, map::B256Set};
 /// Used by the [`crate::proof::ProofRetainer`] to determine which nodes may be ancestors of newly
 /// added or removed leaves. This information allows for generation of more complete proofs which
 /// include the nodes necessary for adding and removing leaves from the trie.
+///
+/// Note: Currently only removed keys are tracked. Added keys tracking is not yet implemented.
 #[derive(Debug, Default, Clone)]
 pub struct AddedRemovedKeys {
     /// Keys which are known to be removed from the trie.
     removed_keys: B256Set,
-    /// Keys which are known to be newly added to the trie.
+    /// Keys which are known to be added to the trie.
     added_keys: B256Set,
+    /// Assume that all keys have been added.
+    assume_added: bool,
 }
 
 impl AsRef<Self> for AddedRemovedKeys {
@@ -21,6 +25,14 @@ impl AsRef<Self> for AddedRemovedKeys {
 }
 
 impl AddedRemovedKeys {
+    /// Sets the `assume_added` flag, which can be used instead of `insert_added` if exact
+    /// additions aren't known and you want to optimistically collect all proofs which _might_ be
+    /// necessary.
+    pub fn with_assume_added(mut self, assume_added: bool) -> Self {
+        self.assume_added = assume_added;
+        self
+    }
+
     /// Sets the key as being a removed key. This removes the key from the `added_keys` set if it
     /// was previously inserted into it.
     pub fn insert_removed(&mut self, key: B256) {
@@ -47,15 +59,16 @@ impl AddedRemovedKeys {
 
     /// Returns true if the given key path is marked as added.
     pub fn is_added(&self, path: &B256) -> bool {
-        self.added_keys.contains(path)
+        self.assume_added || self.added_keys.contains(path)
     }
 
     /// Returns true if the given path prefix is the prefix of an added key.
     pub fn is_prefix_added(&self, prefix: &Nibbles) -> bool {
-        self.added_keys.iter().any(|key| {
-            let key_nibbles = Nibbles::unpack(key);
-            key_nibbles.starts_with(prefix)
-        })
+        self.assume_added
+            || self.added_keys.iter().any(|key| {
+                let key_nibbles = Nibbles::unpack(key);
+                key_nibbles.starts_with(prefix)
+            })
     }
 
     /// Returns a mask containing a bit set for each child of the branch which is a prefix of a

--- a/src/proof/added_removed_keys.rs
+++ b/src/proof/added_removed_keys.rs
@@ -6,8 +6,6 @@ use alloy_primitives::{B256, map::B256Set};
 /// Used by the [`crate::proof::ProofRetainer`] to determine which nodes may be ancestors of newly
 /// added or removed leaves. This information allows for generation of more complete proofs which
 /// include the nodes necessary for adding and removing leaves from the trie.
-///
-/// Note: Currently only removed keys are tracked. Added keys tracking is not yet implemented.
 #[derive(Debug, Default, Clone)]
 pub struct AddedRemovedKeys {
     /// Keys which are known to be removed from the trie.

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -22,4 +22,4 @@ mod retainer;
 pub use retainer::ProofRetainer;
 
 mod added_removed_keys;
-pub use added_removed_keys::{AddedRemovedKeys, EmptyAddedRemovedKeys};
+pub use added_removed_keys::AddedRemovedKeys;

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -20,3 +20,6 @@ pub use proof_nodes::ProofNodes;
 
 mod retainer;
 pub use retainer::ProofRetainer;
+
+mod added_removed_keys;
+pub use added_removed_keys::{AddedRemovedKeys, EmptyAddedRemovedKeys};

--- a/src/proof/retainer.rs
+++ b/src/proof/retainer.rs
@@ -89,7 +89,6 @@ impl FromIterator<Nibbles> for ProofRetainer {
 impl ProofRetainer {
     /// Create new retainer with target nibbles.
     pub fn new(targets: Vec<Nibbles>) -> Self {
-        trace!(target: "trie::proof_retainer", ?targets, "Initializing");
         Self { targets, ..Default::default() }
     }
 }

--- a/src/proof/retainer.rs
+++ b/src/proof/retainer.rs
@@ -31,9 +31,8 @@ impl SeenProofs {
 
     /// Checks if a branch node is parent to both last target leaf and last non-target node.
     fn branch_is_parent(&self, path: &Nibbles) -> bool {
-        let l = path.len();
-        self.last_target_leaf_path.len() == l + 1
-            && self.last_nontarget_path.len() == l + 1
+        self.last_target_leaf_path.len() == path.len() + 1
+            && self.last_nontarget_path.len() == path.len() + 1
             && self.last_target_leaf_path.starts_with(path)
             && self.last_nontarget_path.starts_with(path)
     }

--- a/src/proof/retainer.rs
+++ b/src/proof/retainer.rs
@@ -47,7 +47,7 @@ impl AddedRemovedKeysTracking {
     }
 
     /// Checks if an extension node is parent to the last tracked branch node.
-    fn extension_child_is_branch(&self, path: &Nibbles, short_key: &Nibbles) -> bool {
+    fn extension_child_is_nontarget(&self, path: &Nibbles, short_key: &Nibbles) -> bool {
         path.len() + short_key.len() == self.last_nontarget_path.len()
             && self.last_nontarget_path.starts_with(path)
             && self.last_nontarget_path.ends_with(short_key)
@@ -216,19 +216,17 @@ impl<K: AsRef<AddedRemovedKeys>> ProofRetainer<K> {
                 // non-target children of target extensions.
                 //
                 let is_prefix_added = added_removed_keys.as_ref().is_prefix_added(path);
-                let extension_child_is_branch =
-                    self.added_removed_tracking.extension_child_is_branch(path, short_key);
-                let extension_child_is_nontarget = self.matches(path);
+                let extension_child_is_nontarget =
+                    self.added_removed_tracking.extension_child_is_nontarget(path, short_key);
                 trace!(
                     target: "trie::proof_retainer",
                     ?path,
                     ?short_key,
                     ?is_prefix_added,
-                    ?extension_child_is_branch,
                     ?extension_child_is_nontarget,
                     "Deciding to retain non-target extension child",
                 );
-                if is_prefix_added && extension_child_is_branch && extension_child_is_nontarget {
+                if is_prefix_added && extension_child_is_nontarget {
                     let last_branch_path = self.added_removed_tracking.last_branch_path;
                     let last_branch_proof =
                         Bytes::copy_from_slice(&self.added_removed_tracking.last_branch_proof);

--- a/src/proof/retainer.rs
+++ b/src/proof/retainer.rs
@@ -1,7 +1,50 @@
-use crate::{Nibbles, proof::ProofNodes};
+use crate::{Nibbles, TrieMask, proof::ProofNodes};
 use alloy_primitives::Bytes;
+use alloy_rlp::EMPTY_STRING_CODE;
 
 use alloc::vec::Vec;
+
+/// Tracks various datapoints related to already-seen proofs which may or may not have been
+/// retained in the outer [`ProofRetainer`].
+///
+/// "target" refers those paths/proofs which are retained by the [`ProofRetainer`], as determined
+/// by its `target` field.
+#[derive(Default, Clone, Debug)]
+struct SeenProofs {
+    last_target_leaf_path: Nibbles,
+    last_nontarget_path: Nibbles,
+    last_nontarget_proof: Vec<u8>,
+}
+
+impl SeenProofs {
+    /// Stores the path of the most recently seen target leaf.
+    fn retain_target_leaf(&mut self, path: &Nibbles) {
+        self.last_target_leaf_path = *path;
+    }
+
+    /// Stores the path and proof of the most recently seen path/proof which were not retained.
+    fn retain_nontarget(&mut self, path: &Nibbles, proof: &[u8]) {
+        self.last_nontarget_path = *path;
+        self.last_nontarget_proof.clear();
+        self.last_nontarget_proof.extend(proof);
+    }
+
+    /// Checks if a branch node is parent to both last target leaf and last non-target node.
+    fn branch_is_parent(&self, path: &Nibbles) -> bool {
+        let l = path.len();
+        self.last_target_leaf_path.len() == l + 1
+            && self.last_nontarget_path.len() == l + 1
+            && self.last_target_leaf_path.starts_with(path)
+            && self.last_nontarget_path.starts_with(path)
+    }
+
+    /// Checks if an extension node is parent to the last non-target node.
+    fn extension_child_is_nontarget(&self, path: &Nibbles, short_key: &Nibbles) -> bool {
+        path.len() + short_key.len() == self.last_nontarget_path.len()
+            && self.last_nontarget_path.starts_with(path)
+            && self.last_nontarget_path.ends_with(short_key)
+    }
+}
 
 /// Proof retainer is used to store proofs during merkle trie construction.
 /// It is intended to be used within the [`HashBuilder`](crate::HashBuilder).
@@ -11,6 +54,9 @@ pub struct ProofRetainer {
     targets: Vec<Nibbles>,
     /// The map retained trie node keys to RLP serialized trie nodes.
     proof_nodes: ProofNodes,
+    /// Tracks data related to previously seen proofs; required for certain edge-cases where we
+    /// want to keep proofs for nodes which aren't in the target set.
+    seen_proofs: Option<SeenProofs>,
 }
 
 impl FromIterator<Nibbles> for ProofRetainer {
@@ -22,12 +68,20 @@ impl FromIterator<Nibbles> for ProofRetainer {
 impl ProofRetainer {
     /// Create new retainer with target nibbles.
     pub fn new(targets: Vec<Nibbles>) -> Self {
-        Self { targets, proof_nodes: Default::default() }
+        Self { targets, ..Default::default() }
+    }
+
+    /// Configures the retainer to retain proofs for certain nodes which would otherwise fall
+    /// outside the target set, when those nodes might be required for performing leaf
+    /// addition/removal.
+    pub fn with_leaf_additions_removals(mut self, keep: bool) -> Self {
+        self.seen_proofs = keep.then(Default::default);
+        self
     }
 
     /// Returns `true` if the given prefix matches the retainer target.
     pub fn matches(&self, prefix: &Nibbles) -> bool {
-        self.targets.iter().any(|target| target.starts_with(prefix))
+        prefix.is_empty() || self.targets.iter().any(|target| target.starts_with(prefix))
     }
 
     /// Returns all collected proofs.
@@ -36,9 +90,142 @@ impl ProofRetainer {
     }
 
     /// Retain the proof if the key matches any of the targets.
+    ///
+    /// Usage of this method should be replaced with usage of the following methods, each dependent
+    /// on the node-type whose proof being retained:
+    /// - `retain_empty_root_proof`
+    /// - `retain_leaf_proof`
+    /// - `retain_extension_proof`
+    /// - `retain_branch_proof`
+    #[deprecated]
     pub fn retain(&mut self, prefix: &Nibbles, proof: &[u8]) {
-        if prefix.is_empty() || self.matches(prefix) {
-            self.proof_nodes.insert(*prefix, Bytes::from(proof.to_vec()));
+        if self.matches(prefix) {
+            self.retain_unchecked(*prefix, Bytes::copy_from_slice(proof));
+        }
+    }
+
+    /// Retain the proof with no checks being performed.
+    fn retain_unchecked(&mut self, prefix: Nibbles, proof: Bytes) {
+        tracing::trace!(
+            target: "trie::proof_retainer",
+            path = ?prefix,
+            proof = alloy_primitives::hex::encode(&proof),
+            "Retaining proof",
+        );
+        self.proof_nodes.insert(prefix, proof);
+    }
+
+    /// Retains a proof for an empty root.
+    pub fn retain_empty_root_proof(&mut self) {
+        self.retain_unchecked(Nibbles::default(), [EMPTY_STRING_CODE].into())
+    }
+
+    /// Retains a proof for a leaf node.
+    pub fn retain_leaf_proof(&mut self, prefix: &Nibbles, proof: &[u8]) {
+        let is_target = if self.matches(prefix) {
+            self.retain_unchecked(*prefix, Bytes::copy_from_slice(proof));
+            true
+        } else {
+            false
+        };
+
+        if let Some(seen_proofs) = self.seen_proofs.as_mut() {
+            if is_target {
+                seen_proofs.retain_target_leaf(prefix);
+            } else {
+                seen_proofs.retain_nontarget(prefix, proof);
+            }
+        }
+    }
+
+    /// Retains a proof for an extension node.
+    pub fn retain_extension_proof(&mut self, prefix: &Nibbles, short_key: &Nibbles, proof: &[u8]) {
+        if self.matches(prefix) {
+            self.retain_unchecked(*prefix, Bytes::copy_from_slice(proof));
+
+            // When a new leaf is being added to a trie, it can happen that an extension node's
+            // path is a prefix of the new leaf's, but the extension child's path is not. In
+            // this case a new branch node is created; the new leaf is one child, the previous
+            // branch node is its other, and the extension node is its parent.
+            //
+            //            Before │ After
+            //                   │
+            //   ┌───────────┐   │    ┌───────────┐
+            //   │ Extension │   │    │ Extension │
+            //   └─────┬─────┘   │    └─────┬─────┘
+            //         │         │          │
+            //         │         │    ┌─────┴──────┐
+            //         │         │    │ New Branch │
+            //         │         │    └─────┬───┬──┘
+            //         │         │          │   └─────┐
+            //   ┌─────┴────┐    │    ┌─────┴────┐  ┌─┴────────┐
+            //   │  Branch  │    │    │  Branch  │  │ New Leaf │
+            //   └──────────┘    │    └──────────┘  └──────────┘
+            //
+            // In this case the new leaf's proof will be retained, as will the extension's because
+            // its path is a prefix of the leaf's. But the old branch's proof won't necessarily be
+            // retained, as its path is not a prefix of the leaf's. In order to support this case
+            // retain the proof for non-target children of target extensions.
+            //
+            if let Some(seen_proofs) = self.seen_proofs.as_ref() {
+                if seen_proofs.extension_child_is_nontarget(prefix, short_key) {
+                    self.retain_unchecked(
+                        seen_proofs.last_nontarget_path,
+                        Bytes::copy_from_slice(&seen_proofs.last_nontarget_proof),
+                    );
+                }
+            }
+        } else if let Some(seen_proofs) = self.seen_proofs.as_mut() {
+            seen_proofs.retain_nontarget(prefix, proof);
+        }
+    }
+
+    /// Retains a proof for a branch node.
+    pub fn retain_branch_proof(&mut self, prefix: &Nibbles, state_mask: TrieMask, proof: &[u8]) {
+        if self.matches(prefix) {
+            self.retain_unchecked(*prefix, Bytes::copy_from_slice(proof));
+
+            // When removing a leaf node from the trie, and the leaf node's branch only has one
+            // other child, that branch gets "collapsed" into its parent branch/extension, i.e. it
+            // is deleted and the remaining child is adopted by its grandparent.
+            //
+            //                           Before │ After
+            //                                  │
+            //   ┌───────────────┐              │    ┌───────────────┐
+            //   │  Grandparent  │              │    │  Grandparent  │
+            //   │  Branch       │              │    │  Branch       │
+            //   └──┬───┬───┬────┘              │    └──┬───┬───┬────┘
+            //      :   :   │                   │       :   :   │
+            //              │                   │               │
+            //   ┌──────────┴──────┐            │               │
+            //   │  Parent Branch  │            │               │
+            //   └──────────┬──┬───┘            │               │
+            //              │  └─────┐          │               │
+            //   ┌──────────┴─────┐ ┌┴─────┐    │    ┌──────────┴─────┐
+            //   │  Child Branch  │ │ Leaf │    │    │  Child Branch  │
+            //   └──┬───┬───┬─────┘ └──────┘    │    └────────────────┘
+            //      :   :   :                   │
+            //
+            // The adopted child can also be a leaf or extension, which can affect what happens to
+            // the grandparent, so it must have a proof in order to perform a collapse. The proof
+            // of the removed leaf will always be retained, but it can happen that the remaining
+            // child will not be in the `changes` set and so would not be retained.
+            //
+            // To get around this we check here if the branch node has only two children, and if
+            // those children are respectively a retained leaf and an unretained child of any type.
+            // If so we retain the previously-unretained child, in case the leaf ends up getting
+            // removed.
+            //
+            if let Some(seen_proofs) = self.seen_proofs.as_ref() {
+                if state_mask.count_ones() == 2 && seen_proofs.branch_is_parent(prefix) {
+                    self.retain_unchecked(
+                        seen_proofs.last_nontarget_path,
+                        Bytes::copy_from_slice(&seen_proofs.last_nontarget_proof),
+                    );
+                }
+            }
+        } else if let Some(seen_proofs) = self.seen_proofs.as_mut() {
+            seen_proofs.retain_nontarget(prefix, proof);
         }
     }
 }

--- a/src/proof/retainer.rs
+++ b/src/proof/retainer.rs
@@ -1,36 +1,37 @@
-use crate::{Nibbles, TrieMask, proof::ProofNodes};
-use alloy_primitives::{B256, Bytes};
+use crate::{
+    Nibbles, TrieMask,
+    proof::{
+        ProofNodes,
+        added_removed_keys::{AddedRemovedKeys, EmptyAddedRemovedKeys},
+    },
+};
+use alloy_primitives::Bytes;
 use alloy_rlp::EMPTY_STRING_CODE;
 
 use alloc::vec::Vec;
 
 /// Tracks various datapoints related to already-seen proofs which may or may not have been
-/// retained in the outer [`ProofRetainer`].
+/// retained in the outer [`ProofRetainer`]. Used to support retention of extra proofs which are
+/// required to support leaf additions/removals but aren't in the target set.
 ///
 /// "target" refers those paths/proofs which are retained by the [`ProofRetainer`], as determined
 /// by its `target` field.
-#[derive(Clone, Debug)]
-struct SeenProofs {
+#[derive(Default, Clone, Debug)]
+struct AddedRemovedKeysTracking {
+    /// Path of the last node which was not found in the `ProofRetainer`'s target set.
     last_nontarget_path: Nibbles,
+    /// Proof of the last node which was not found in the `ProofRetainer`'s target set.
     last_nontarget_proof: Vec<u8>,
-    /// Tracks a mask for each branch node, with a bit set for children which are a target.
-    /// Branches are indexed by their path length.
-    branch_target_masks: Vec<TrieMask>,
 }
 
-impl Default for SeenProofs {
-    fn default() -> Self {
-        Self {
-            last_nontarget_path: Default::default(),
-            last_nontarget_proof: Default::default(),
-            branch_target_masks: Vec::with_capacity(B256::ZERO.len() * 8),
-        }
-    }
-}
-
-impl SeenProofs {
+impl AddedRemovedKeysTracking {
     /// Stores the path and proof of the most recently seen path/proof which were not retained.
     fn retain_nontarget(&mut self, path: &Nibbles, proof: &[u8]) {
+        tracing::trace!(
+            target: "trie::proof_retainer",
+            ?path,
+            "Retaining non-target",
+        );
         self.last_nontarget_path = *path;
         self.last_nontarget_proof.clear();
         self.last_nontarget_proof.extend(proof);
@@ -43,40 +44,11 @@ impl SeenProofs {
             && self.last_nontarget_path.ends_with(short_key)
     }
 
-    /// Returns mutable reference to the target mask for the branch at the given index, where the
-    /// index is equivalent to the branch path's length.
-    fn branch_target_mask_mut(&mut self, branch_idx: usize) -> &mut TrieMask {
-        // Ensure the `branch_target_masks` Vec has been extended far enough so that this
-        // branch index has a mask to work with.
-        if self.branch_target_masks.len() <= branch_idx {
-            self.branch_target_masks.resize(branch_idx + 1, TrieMask::default());
-        }
-        &mut self.branch_target_masks[branch_idx]
-    }
-
-    /// When passed the path of a node whose parent is a branch, this marks the bit for the child
-    /// on that branch's mask.
-    ///
-    /// When passed the path of a node whose parent is _not_ a branch, this marks the bit in the
-    /// corresponding mask anyway, but because there won't be a branch at that index the mask will
-    /// be discarded.
-    fn set_branch_child_target_bit(&mut self, path: &Nibbles) {
-        let branch_idx = path.len() - 1;
-        let child_bit = path.last().expect("root node cannot be a branch child");
-        self.branch_target_mask_mut(branch_idx).set_bit(child_bit);
-    }
-
-    /// Removes the target mask for the branch of the given index, as well as all masks with a
-    /// larger index.
-    fn take_branch_target_mask(&mut self, branch_idx: usize) -> TrieMask {
-        // There are cases where a branch will be a target but none of its children will be, e.g.
-        // when a child is leaf which will be created
-        if let Some(mask) = self.branch_target_masks.get(branch_idx).copied() {
-            self.branch_target_masks.truncate(branch_idx);
-            mask
-        } else {
-            TrieMask::default()
-        }
+    /// Checks if a branch node is parent to the last non-target node.
+    fn branch_child_is_nontarget(&self, path: &Nibbles, child_nibble: u8) -> bool {
+        path.len() + 1 == self.last_nontarget_path.len()
+            && self.last_nontarget_path.starts_with(path)
+            && self.last_nontarget_path.last().expect("path length >= 1") == child_nibble
     }
 }
 
@@ -87,14 +59,16 @@ impl SeenProofs {
 /// methods, it is required that the calls are ordered such that proofs of parent nodes are
 /// retained after their children.
 #[derive(Default, Clone, Debug)]
-pub struct ProofRetainer {
+pub struct ProofRetainer<K = EmptyAddedRemovedKeys> {
     /// The nibbles of the target trie keys to retain proofs for.
     targets: Vec<Nibbles>,
     /// The map retained trie node keys to RLP serialized trie nodes.
     proof_nodes: ProofNodes,
+    /// Provided by the user to give the necessary context to retain extra proofs.
+    added_removed_keys: Option<K>,
     /// Tracks data related to previously seen proofs; required for certain edge-cases where we
     /// want to keep proofs for nodes which aren't in the target set.
-    seen_proofs: Option<SeenProofs>,
+    added_removed_tracking: AddedRemovedKeysTracking,
 }
 
 impl FromIterator<Nibbles> for ProofRetainer {
@@ -113,13 +87,25 @@ impl ProofRetainer {
         );
         Self { targets, ..Default::default() }
     }
+}
 
+impl<RK> ProofRetainer<RK> {
     /// Configures the retainer to retain proofs for certain nodes which would otherwise fall
-    /// outside the target set, when those nodes might be required for performing leaf
-    /// addition/removal.
-    pub fn with_leaf_additions_removals(mut self, keep: bool) -> Self {
-        self.seen_proofs = keep.then(Default::default);
-        self
+    /// outside the target set, when those nodes might be required to calculate the state root when
+    /// keys have been added or removed to the trie.
+    ///
+    /// If None is given then retention of extra proofs is disabled.
+    pub fn with_added_removed_keys<K2>(self, added_removed_keys: Option<K2>) -> ProofRetainer<K2> {
+        ProofRetainer {
+            targets: self.targets,
+            proof_nodes: self.proof_nodes,
+            added_removed_keys,
+            added_removed_tracking: self.added_removed_tracking,
+        }
+    }
+
+    fn added_removed_tracking_enabled(&self) -> bool {
+        self.added_removed_keys.is_some()
     }
 
     /// Returns `true` if the given prefix matches the retainer target.
@@ -158,6 +144,14 @@ impl ProofRetainer {
         self.proof_nodes.insert(path, proof);
     }
 
+    /// Retain the proof of the last seen node which was not a target node.
+    fn retain_last_nontarget(&mut self) {
+        let last_nontarget_path = self.added_removed_tracking.last_nontarget_path;
+        let last_nontarget_proof =
+            Bytes::copy_from_slice(&self.added_removed_tracking.last_nontarget_proof);
+        self.retain_unchecked(last_nontarget_path, last_nontarget_proof);
+    }
+
     /// Retains a proof for an empty root.
     pub fn retain_empty_root_proof(&mut self) {
         self.retain_unchecked(Nibbles::default(), [EMPTY_STRING_CODE].into())
@@ -165,35 +159,24 @@ impl ProofRetainer {
 
     /// Retains a proof for a leaf node.
     pub fn retain_leaf_proof(&mut self, path: &Nibbles, proof: &[u8]) {
-        let is_target = if self.matches(path) {
+        if self.matches(path) {
             self.retain_unchecked(*path, Bytes::copy_from_slice(proof));
-            true
-        } else {
-            false
+        } else if self.added_removed_tracking_enabled() {
+            self.added_removed_tracking.retain_nontarget(path, proof);
         };
-
-        if let Some(seen_proofs) = self.seen_proofs.as_mut() {
-            if is_target && !path.is_empty() {
-                seen_proofs.set_branch_child_target_bit(path);
-            } else {
-                seen_proofs.retain_nontarget(path, proof);
-            }
-        }
     }
+}
 
+impl<K: AddedRemovedKeys> ProofRetainer<K> {
     /// Retains a proof for an extension node.
     pub fn retain_extension_proof(&mut self, path: &Nibbles, short_key: &Nibbles, proof: &[u8]) {
         if self.matches(path) {
             self.retain_unchecked(*path, Bytes::copy_from_slice(proof));
 
-            if let Some(seen_proofs) = self.seen_proofs.as_mut() {
-                if !path.is_empty() {
-                    seen_proofs.set_branch_child_target_bit(path);
-                }
-
+            if let Some(added_removed_keys) = self.added_removed_keys.as_ref() {
                 // When a new leaf is being added to a trie, it can happen that an extension node's
-                // path is a path of the new leaf's, but the extension child's path is not. In this
-                // case a new branch node is created; the new leaf is one child, the previous
+                // path is a prefix of the new leaf's, but the extension child's path is not. In
+                // this case a new branch node is created; the new leaf is one child, the previous
                 // branch node is its other, and the extension node is its parent.
                 //
                 //            Before │ After
@@ -210,20 +193,37 @@ impl ProofRetainer {
                 //   │  Branch  │    │    │  Branch  │  │ New Leaf │
                 //   └──────────┘    │    └──────────┘  └──────────┘
                 //
-                // In this case the new leaf's proof will be retained, as will the extension's
-                // because its path is a path of the leaf's. But the old branch's proof won't
-                // necessarily be retained, as its path is not a path of the leaf's. In order to
-                // support this case retain the proof for non-target children of target extensions.
+                // In this case the new leaf's proof will be retained, as will the extension's,
+                // because its path is a prefix of the leaf's. But the old branch's proof won't
+                // necessarily be retained, as its path is not a prefix of the leaf's.
                 //
-                if seen_proofs.extension_child_is_nontarget(path, short_key) {
-                    let last_nontarget_path = seen_proofs.last_nontarget_path;
-                    let last_nontarget_proof =
-                        Bytes::copy_from_slice(&seen_proofs.last_nontarget_proof);
-                    self.retain_unchecked(last_nontarget_path, last_nontarget_proof);
+                // In order to support this case we can optimistically retain the proof for
+                // non-target children of target extensions.
+                //
+                let is_prefix_added = added_removed_keys.is_prefix_added(path);
+                let extension_child_is_nontarget =
+                    self.added_removed_tracking.extension_child_is_nontarget(path, short_key);
+                tracing::trace!(
+                    target: "trie::proof_retainer",
+                    ?path,
+                    ?short_key,
+                    ?is_prefix_added,
+                    ?extension_child_is_nontarget,
+                    "Deciding to retain non-target",
+                );
+                if added_removed_keys.is_prefix_added(path)
+                    && self.added_removed_tracking.extension_child_is_nontarget(path, short_key)
+                {
+                    self.retain_last_nontarget();
                 }
+            } else {
+                tracing::trace!(
+                    target: "trie::proof_retainer",
+                    "added_removed_keys is None???",
+                );
             }
-        } else if let Some(seen_proofs) = self.seen_proofs.as_mut() {
-            seen_proofs.retain_nontarget(path, proof);
+        } else if self.added_removed_tracking_enabled() {
+            self.added_removed_tracking.retain_nontarget(path, proof);
         }
     }
 
@@ -232,23 +232,7 @@ impl ProofRetainer {
         if self.matches(path) {
             self.retain_unchecked(*path, Bytes::copy_from_slice(proof));
 
-            if let Some(seen_proofs) = self.seen_proofs.as_mut() {
-                // Don't set branch target bit if this is the root, it has no parent
-                if !path.is_empty() {
-                    seen_proofs.set_branch_child_target_bit(path);
-                }
-
-                // Calculate non-target children for the next step
-                let target_mask = seen_proofs.take_branch_target_mask(path.len());
-
-                debug_assert_eq!(
-                    state_mask | target_mask,
-                    state_mask,
-                    "target mask {target_mask:?} of {path:?} has extra bits set"
-                );
-
-                let nontarget_mask = !target_mask & state_mask;
-
+            if let Some(added_removed_keys) = self.added_removed_keys.as_ref() {
                 // When we remove all but one child from a branch, that branch gets "collapsed"
                 // into its parent branch/extension, i.e. it is deleted and the remaining child is
                 // adopted by its grandparent.
@@ -274,23 +258,26 @@ impl ProofRetainer {
                 // to the grandparent, so to perform a collapse we must retain a proof of the
                 // adopted child.
                 //
-                // The proofs of the removed children will always be retained, but it can happen
-                // that the remaining child will not be in the `target` set and so would not be
-                // retained.
+                // The proofs of the removed children will be retained if they are in the `target`
+                // set, but it can happen that the remaining child will not be in the `target` set
+                // and so would not be retained.
                 //
-                // The `target` set does not give us fine-grained context on whether nodes will be
-                // removed or simply changed, so we have to be over-eager in retaining proofs and
-                // always assume that if all children but one are targets, then we need to keep the
-                // remaining non-target.
-                if nontarget_mask.count_ones() == 1 {
-                    let last_nontarget_path = seen_proofs.last_nontarget_path;
-                    let last_nontarget_proof =
-                        Bytes::copy_from_slice(&seen_proofs.last_nontarget_proof);
-                    self.retain_unchecked(last_nontarget_path, last_nontarget_proof);
+                // Using `removed_keys` we can discern if there is one remaining child in a branch
+                // which is not a target, and optimistically retain that child if so.
+                //
+                let removed_mask = added_removed_keys.get_removed_mask(path);
+                let nonremoved_mask = !removed_mask & state_mask;
+
+                if nonremoved_mask.count_ones() == 1
+                    && self
+                        .added_removed_tracking
+                        .branch_child_is_nontarget(path, nonremoved_mask.trailing_zeros() as u8)
+                {
+                    self.retain_last_nontarget();
                 }
             }
-        } else if let Some(seen_proofs) = self.seen_proofs.as_mut() {
-            seen_proofs.retain_nontarget(path, proof);
+        } else if self.added_removed_tracking_enabled() {
+            self.added_removed_tracking.retain_nontarget(path, proof);
         }
     }
 }

--- a/src/proof/retainer.rs
+++ b/src/proof/retainer.rs
@@ -149,7 +149,7 @@ impl<K: AsRef<AddedRemovedKeys>> ProofRetainer<K> {
 
     /// Retains a proof for an empty root.
     pub fn retain_empty_root_proof(&mut self) {
-        self.retain_unchecked(Nibbles::default(), [EMPTY_STRING_CODE].into())
+        self.retain_unchecked(Nibbles::default(), Bytes::from_static(&[EMPTY_STRING_CODE]))
     }
 
     /// Tracks the proof in the [`AddedRemovedKeysTracking`] if:

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -206,7 +206,8 @@ mod tests {
     #[test]
     fn empty_trie() {
         let key = Nibbles::unpack(B256::repeat_byte(42));
-        let mut hash_builder = HashBuilder::default().with_proof_retainer(ProofRetainer::default());
+        let mut hash_builder =
+            HashBuilder::default().with_proof_retainer(<ProofRetainer>::default());
         let root = hash_builder.root();
         let proof = hash_builder.take_proof_nodes();
         assert_eq!(


### PR DESCRIPTION
There are specific edge-cases where it's necessary to retain the proofs for nodes which aren't given in the target set, namely leaf removals which result in the deletion of a branch, and leaf additions which result in the creation of a branch.

Documentation of each case is provided in the code at the point it is handled.

This change will cause more proofs than are strictly necessary to be retained, because the `target` set we are given does not tell us if paths are added, updated or removed. This extra work is made up for by us not needing to fetch the nodes which would otherwise be missing later down the pipeline, and in benchmarking the overall change comes out very slightly faster.

Partially addresses https://github.com/paradigmxyz/reth/issues/17571