### PR TITLE
bump nybbles version to include pack_to_unchecked fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ derive_more = { version = "2", default-features = false, features = [
     "from",
     "not",
 ] }
-nybbles = { version = "0.4", default-features = false }
+nybbles = { version = ">=0.4.3, <0.5.0", default-features = false }
 smallvec = { version = "1.0", default-features = false, features = [
     "const_new",
 ] }


### PR DESCRIPTION
## Problem
The current [`nybbles`](https://github.com/alloy-rs/nybbles) dependency (`0.4.0`) contains unsafe memory handling that causes non-deterministic behavior in MIPS VM environments. See [here](https://github.com/alloy-rs/trie/issues/110) for more details.

## Solution
Update `nybbles` to `>=0.4.3` which contains the fix for the memory corruption issue in unsafe blocks.

## Testing
Confirmed that this change resolves determinism issues in [Cannon](https://github.com/op-rs/kona) (MIPS VM) fault proof environments.