### PR TITLE
chore: `missing-const-for-fn` lint back to "warn".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ all = "warn"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }
-missing-const-for-fn = "allow"          # TODO: https://github.com/rust-lang/rust-clippy/issues/14020
+missing-const-for-fn = "warn"
 use-self = "warn"
 redundant-clone = "warn"
 result_large_err = "allow"

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -84,13 +84,13 @@ impl TrieMask {
 
     /// Set bit at a specified index.
     #[inline]
-    pub fn set_bit(&mut self, index: u8) {
+    pub const fn set_bit(&mut self, index: u8) {
         self.0 |= 1u16 << index;
     }
 
     /// Unset bit at a specified index.
     #[inline]
-    pub fn unset_bit(&mut self, index: u8) {
+    pub const fn unset_bit(&mut self, index: u8) {
         self.0 &= !(1u16 << index);
     }
 }

--- a/src/nodes/extension.rs
+++ b/src/nodes/extension.rs
@@ -133,7 +133,7 @@ impl<'a> ExtensionNodeRef<'a> {
 
     /// Returns the length of RLP encoded fields of extension node.
     #[inline]
-    fn rlp_payload_length(&self) -> usize {
+    const fn rlp_payload_length(&self) -> usize {
         let mut encoded_key_len = self.key.len() / 2 + 1;
         // For extension nodes the first byte cannot be greater than 0x80.
         if encoded_key_len != 1 {

--- a/src/proof/added_removed_keys.rs
+++ b/src/proof/added_removed_keys.rs
@@ -26,7 +26,7 @@ impl AddedRemovedKeys {
     /// Sets the `assume_added` flag, which can be used instead of `insert_added` if exact
     /// additions aren't known and you want to optimistically collect all proofs which _might_ be
     /// necessary.
-    pub fn with_assume_added(mut self, assume_added: bool) -> Self {
+    pub const fn with_assume_added(mut self, assume_added: bool) -> Self {
         self.assume_added = assume_added;
         self
     }


### PR DESCRIPTION
## Motivation

In the same vein as https://github.com/alloy-rs/evm/pull/167 and https://github.com/alloy-rs/op-alloy/pull/593

## Solution

- `missing-const-for-fn` lint set to warn.
-  Updated some funtions to `const` in order to comply with the updated lint level.