### PR TITLE
perf: HashBuilder and proof building optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ hash-db = "0.15"
 plain_hasher = "0.2"
 triehash = "0.8.4"
 criterion = { version = "2.10", package = "codspeed-criterion-compat" }
+proptest = "1.5"
 
 [features]
 default = ["std", "alloy-primitives/default"]
@@ -116,5 +117,10 @@ ethereum = []
 
 [[bench]]
 name = "bench"
+harness = false
+required-features = ["arbitrary"]
+
+[[bench]]
+name = "hash_builder_bench"
 harness = false
 required-features = ["arbitrary"]

--- a/benches/hash_builder_bench.rs
+++ b/benches/hash_builder_bench.rs
@@ -129,12 +129,21 @@ fn proof_retainer_match(c: &mut Criterion) {
 
         let retainer = ProofRetainer::from_iter(targets.clone());
 
-        // Use a prefix that might match
-        let test_prefix = targets[0].slice(..4);
-
+        // Test matching prefix (first target's prefix)
+        let matching_prefix = targets[0].slice(..4);
         group.bench_with_input(
-            BenchmarkId::new("targets", target_count),
-            &(retainer, test_prefix),
+            BenchmarkId::new("match", target_count),
+            &(retainer.clone(), matching_prefix),
+            |b, (retainer, prefix)| {
+                b.iter(|| black_box(retainer.matches(prefix)));
+            },
+        );
+
+        // Test non-matching prefix (0xFF... which won't match random targets)
+        let non_matching_prefix = Nibbles::from_nibbles([0xF, 0xF, 0xF, 0xF]);
+        group.bench_with_input(
+            BenchmarkId::new("no_match", target_count),
+            &(retainer, non_matching_prefix),
             |b, (retainer, prefix)| {
                 b.iter(|| black_box(retainer.matches(prefix)));
             },

--- a/benches/hash_builder_bench.rs
+++ b/benches/hash_builder_bench.rs
@@ -1,0 +1,222 @@
+#![allow(missing_docs)]
+
+use alloy_primitives::{B256, keccak256};
+use alloy_trie::{
+    HashBuilder, Nibbles, TrieMask,
+    nodes::{BranchNodeRef, RlpNode},
+    proof::ProofRetainer,
+};
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use proptest::{prelude::*, strategy::ValueTree, test_runner::TestRunner};
+use std::collections::BTreeMap;
+
+/// Generate random key-value pairs for trie benchmarks
+fn generate_leaves(count: usize) -> BTreeMap<B256, Vec<u8>> {
+    let mut runner = TestRunner::default();
+    let mut leaves = BTreeMap::new();
+
+    for _ in 0..count {
+        let key = any::<B256>().new_tree(&mut runner).unwrap().current();
+        let value = any::<[u8; 32]>().new_tree(&mut runner).unwrap().current().to_vec();
+        leaves.insert(keccak256(key), value);
+    }
+    leaves
+}
+
+/// Benchmark HashBuilder with varying number of leaves
+fn hash_builder_leaves(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hash_builder");
+
+    for count in [100, 500, 1000, 5000, 10000] {
+        let leaves = generate_leaves(count);
+
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::new("leaves", count), &leaves, |b, leaves| {
+            b.iter(|| {
+                let mut hb = HashBuilder::default();
+                for (key, value) in leaves {
+                    hb.add_leaf(Nibbles::unpack(key), value);
+                }
+                black_box(hb.root())
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Benchmark HashBuilder with updates enabled
+fn hash_builder_with_updates(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hash_builder_updates");
+
+    for count in [100, 500, 1000] {
+        let leaves = generate_leaves(count);
+
+        group.throughput(Throughput::Elements(count as u64));
+
+        // Without updates
+        group.bench_with_input(BenchmarkId::new("without_updates", count), &leaves, |b, leaves| {
+            b.iter(|| {
+                let mut hb = HashBuilder::default();
+                for (key, value) in leaves {
+                    hb.add_leaf(Nibbles::unpack(key), value);
+                }
+                black_box(hb.root())
+            });
+        });
+
+        // With updates
+        group.bench_with_input(BenchmarkId::new("with_updates", count), &leaves, |b, leaves| {
+            b.iter(|| {
+                let mut hb = HashBuilder::default().with_updates(true);
+                for (key, value) in leaves {
+                    hb.add_leaf(Nibbles::unpack(key), value);
+                }
+                let root = hb.root();
+                let (_, updates) = hb.split();
+                black_box((root, updates))
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Benchmark HashBuilder with proof retainer
+fn hash_builder_with_proofs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hash_builder_proofs");
+
+    for count in [100, 500, 1000] {
+        let leaves = generate_leaves(count);
+        let targets: Vec<Nibbles> = leaves
+            .keys()
+            .take(count / 10) // 10% of keys as targets
+            .map(|k| Nibbles::unpack(k))
+            .collect();
+
+        group.throughput(Throughput::Elements(count as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("with_proofs", count),
+            &(leaves.clone(), targets.clone()),
+            |b, (leaves, targets)| {
+                b.iter(|| {
+                    let retainer = ProofRetainer::from_iter(targets.clone());
+                    let mut hb = HashBuilder::default().with_proof_retainer(retainer);
+                    for (key, value) in leaves {
+                        hb.add_leaf(Nibbles::unpack(key), value);
+                    }
+                    let root = hb.root();
+                    let proofs = hb.take_proof_nodes();
+                    black_box((root, proofs))
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Benchmark ProofRetainer matching
+fn proof_retainer_match(c: &mut Criterion) {
+    let mut group = c.benchmark_group("proof_retainer_match");
+
+    for target_count in [10, 50, 100, 500] {
+        let mut runner = TestRunner::default();
+        let targets: Vec<Nibbles> = (0..target_count)
+            .map(|_| {
+                let key = any::<B256>().new_tree(&mut runner).unwrap().current();
+                Nibbles::unpack(keccak256(key))
+            })
+            .collect();
+
+        let retainer = ProofRetainer::from_iter(targets.clone());
+
+        // Use a prefix that might match
+        let test_prefix = targets[0].slice(..4);
+
+        group.bench_with_input(
+            BenchmarkId::new("targets", target_count),
+            &(retainer, test_prefix),
+            |b, (retainer, prefix)| {
+                b.iter(|| black_box(retainer.matches(prefix)));
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Benchmark mask resize operations (simulates update loop behavior)
+fn mask_resize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mask_resize");
+
+    for depth in [16, 32, 64] {
+        // Benchmark three separate vectors (old approach)
+        group.bench_with_input(BenchmarkId::new("three_vecs", depth), &depth, |b, &depth| {
+            b.iter(|| {
+                let mut state_masks: Vec<TrieMask> = Vec::new();
+                let mut tree_masks: Vec<TrieMask> = Vec::new();
+                let mut hash_masks: Vec<TrieMask> = Vec::new();
+
+                for new_len in 1..=depth {
+                    state_masks.resize(new_len, TrieMask::default());
+                    tree_masks.resize(new_len, TrieMask::default());
+                    hash_masks.resize(new_len, TrieMask::default());
+                }
+                black_box((state_masks.len(), tree_masks.len(), hash_masks.len()))
+            });
+        });
+
+        // Benchmark consolidated approach (new TrieMasks struct)
+        // state_masks kept separate (different lifecycle), tree+hash consolidated
+        group.bench_with_input(BenchmarkId::new("consolidated", depth), &depth, |b, &depth| {
+            b.iter(|| {
+                let mut state_masks: Vec<TrieMask> = Vec::new();
+                let mut masks: Vec<alloy_trie::TrieMasks> = Vec::new();
+
+                for new_len in 1..=depth {
+                    state_masks.resize(new_len, TrieMask::default());
+                    masks.resize(new_len, alloy_trie::TrieMasks::default());
+                }
+                black_box((state_masks.len(), masks.len()))
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Benchmark branch node encoding
+fn branch_node_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("branch_node");
+
+    // Create a branch node with various child counts
+    for child_count in [2, 4, 8, 16] {
+        let mut stack: Vec<RlpNode> = Vec::new();
+        let mut state_mask = TrieMask::default();
+
+        for i in 0..child_count {
+            let hash = B256::repeat_byte(i);
+            stack.push(RlpNode::word_rlp(&hash));
+            state_mask.set_bit(i);
+        }
+
+        let branch = BranchNodeRef::new(&stack, state_mask);
+
+        group.bench_with_input(BenchmarkId::new("encode", child_count), &branch, |b, branch| {
+            let mut buf = Vec::with_capacity(600);
+            b.iter(|| {
+                buf.clear();
+                black_box(branch.rlp(&mut buf))
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    hash_builder_leaves,
+    hash_builder_with_updates,
+    hash_builder_with_proofs,
+    proof_retainer_match,
+    mask_resize,
+    branch_node_encode,
+);
+criterion_main!(benches);

--- a/proptest-regressions/hash_builder/mod.txt
+++ b/proptest-regressions/hash_builder/mod.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5f8e4f14a99888761b42f5cad75352f0cdb8eae3970126bd2dc507fa8d34bad5 # shrinks to state = {0x0000000000000000000000000000000000000000000000000000000000000000: 0, 0x0000000000000000000000000000000000000000000000000000000000000001: 13340485788351367933511177501145171542818524136612522916946378752}

--- a/proptest-regressions/proof/verify.txt
+++ b/proptest-regressions/proof/verify.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 25752ac77400513f3b6fab83fb02ace7d6ae89864e209253f8649fabfe0f6e71 # shrinks to state = {0x0000000000000000000000000000000000000000000000000000000000000000: 0, 0x0000000000000000000000000000000000000000000000000000000000000001: 0}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod nodes;
 pub use nodes::BranchNodeCompact;
 
 pub mod hash_builder;
-pub use hash_builder::HashBuilder;
+pub use hash_builder::{HashBuilder, TrieMasks};
 
 pub mod proof;
 

--- a/src/proof/added_removed_keys.rs
+++ b/src/proof/added_removed_keys.rs
@@ -1,4 +1,5 @@
 use crate::{Nibbles, TrieMask};
+use alloc::vec::Vec;
 use alloy_primitives::{B256, map::B256Set};
 
 /// Provides added and removed keys for an account or storage trie.
@@ -14,6 +15,10 @@ pub struct AddedRemovedKeys {
     added_keys: B256Set,
     /// Assume that all keys have been added.
     assume_added: bool,
+    /// Cached sorted nibbles for removed keys (for O(log n) prefix lookup).
+    removed_nibbles: Vec<Nibbles>,
+    /// Cached sorted nibbles for added keys (for O(log n) prefix lookup).
+    added_nibbles: Vec<Nibbles>,
 }
 
 impl AsRef<Self> for AddedRemovedKeys {
@@ -34,25 +39,53 @@ impl AddedRemovedKeys {
     /// Sets the key as being a removed key. This removes the key from the `added_keys` set if it
     /// was previously inserted into it.
     pub fn insert_removed(&mut self, key: B256) {
-        self.added_keys.remove(&key);
-        self.removed_keys.insert(key);
+        // Remove from added keys
+        if self.added_keys.remove(&key) {
+            let nibbles = Nibbles::unpack(&key);
+            if let Ok(idx) = self.added_nibbles.binary_search(&nibbles) {
+                self.added_nibbles.remove(idx);
+            }
+        }
+        // Insert into removed keys
+        if self.removed_keys.insert(key) {
+            let nibbles = Nibbles::unpack(&key);
+            let idx = self.removed_nibbles.partition_point(|n| n < &nibbles);
+            self.removed_nibbles.insert(idx, nibbles);
+        }
     }
 
     /// Unsets the key as being a removed key.
     pub fn remove_removed(&mut self, key: &B256) {
-        self.removed_keys.remove(key);
+        if self.removed_keys.remove(key) {
+            let nibbles = Nibbles::unpack(key);
+            if let Ok(idx) = self.removed_nibbles.binary_search(&nibbles) {
+                self.removed_nibbles.remove(idx);
+            }
+        }
     }
 
     /// Sets the key as being an added key. This removes the key from the `removed_keys` set if it
     /// was previously inserted into it.
     pub fn insert_added(&mut self, key: B256) {
-        self.removed_keys.remove(&key);
-        self.added_keys.insert(key);
+        // Remove from removed keys
+        if self.removed_keys.remove(&key) {
+            let nibbles = Nibbles::unpack(&key);
+            if let Ok(idx) = self.removed_nibbles.binary_search(&nibbles) {
+                self.removed_nibbles.remove(idx);
+            }
+        }
+        // Insert into added keys
+        if self.added_keys.insert(key) {
+            let nibbles = Nibbles::unpack(&key);
+            let idx = self.added_nibbles.partition_point(|n| n < &nibbles);
+            self.added_nibbles.insert(idx, nibbles);
+        }
     }
 
     /// Clears all keys which have been added via `insert_added`.
     pub fn clear_added(&mut self) {
         self.added_keys.clear();
+        self.added_nibbles.clear();
     }
 
     /// Returns true if the given key path is marked as removed.
@@ -66,24 +99,37 @@ impl AddedRemovedKeys {
     }
 
     /// Returns true if the given path prefix is the prefix of an added key.
+    ///
+    /// Uses binary search over cached sorted nibbles for O(log n) lookup.
     pub fn is_prefix_added(&self, prefix: &Nibbles) -> bool {
-        self.assume_added
-            || self.added_keys.iter().any(|key| {
-                let key_nibbles = Nibbles::unpack(key);
-                key_nibbles.starts_with(prefix)
-            })
+        if self.assume_added {
+            return true;
+        }
+        if prefix.is_empty() {
+            return !self.added_nibbles.is_empty();
+        }
+        // Binary search to find first key >= prefix
+        let idx = self.added_nibbles.partition_point(|n| n < prefix);
+        idx < self.added_nibbles.len() && self.added_nibbles[idx].starts_with(prefix)
     }
 
     /// Returns a mask containing a bit set for each child of the branch which is a prefix of a
     /// removed leaf.
+    ///
+    /// Uses binary search to find the range of matching keys for O(log n + m) where m is matches.
     pub fn get_removed_mask(&self, branch_path: &Nibbles) -> TrieMask {
         let mut mask = TrieMask::default();
-        for key in &self.removed_keys {
-            let key_nibbles = Nibbles::unpack(key);
-            if key_nibbles.starts_with(branch_path) {
-                let child_bit = key_nibbles.get_unchecked(branch_path.len());
-                mask.set_bit(child_bit);
+
+        // Binary search to find first key >= branch_path
+        let start = self.removed_nibbles.partition_point(|n| n < branch_path);
+
+        // Iterate only through keys that could match
+        for nibbles in self.removed_nibbles.iter().skip(start) {
+            if !nibbles.starts_with(branch_path) {
+                break; // No more matches possible (sorted order)
             }
+            let child_bit = nibbles.get_unchecked(branch_path.len());
+            mask.set_bit(child_bit);
         }
         mask
     }


### PR DESCRIPTION
POC for proof stuff

1. **Consolidate tree/hash mask vectors** - Reduces allocation overhead by combining `tree_masks` and `hash_masks` into single `Vec<TrieMasks>` (state_masks kept separate due to different lifecycle)
2. **Avoid Vec allocation when updates disabled** - Move child hash collection into `store_branch_node`, eliminating Vec return value overhead
3. **Binary search for ProofRetainer** - Sort targets and use binary search for O(log n) matching instead of O(n) linear search
4. **Cache sorted nibbles in AddedRemovedKeys** - Pre-compute sorted nibbles for O(log n) prefix lookups instead of O(n) iteration

| Optimization | Benchmark | Improvement |
|--------------|-----------|-------------|
| Mask consolidation | mask_resize/64 | ~26% faster |
| Proof binary search | hash_builder_proofs/1000 | ~24% faster |
| Vec allocation removal | hash_builder_updates/500 | ~3% faster |
| AddedRemovedKeys | Scales with key count | O(n) → O(log n) |