### PR TITLE
feat: add OrderedTrieRootBuilder for incremental trie root calculation

### DIFF
--- a/src/root.rs
+++ b/src/root.rs
@@ -106,8 +106,7 @@ impl fmt::Display for OrderedRootError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for OrderedRootError {}
+impl core::error::Error for OrderedRootError {}
 
 /// A builder for computing ordered trie roots incrementally.
 ///


### PR DESCRIPTION
## Summary

Adds two new builder types that allow computing ordered trie roots incrementally as items arrive, rather than requiring all items upfront.

This is useful for receipt root calculation during block execution, where we know the total count but receive receipts one by one as transactions are executed.

## New Types

### `OrderedTrieRootBuilder<T, F>`
For items with a custom encoder function.

```rust
let mut builder = OrderedTrieRootBuilder::new(3, |item: &u64, buf: &mut Vec<u8>| {
    item.encode(buf);
});

builder.push(&100u64).unwrap();
builder.push(&200u64).unwrap();
builder.push(&300u64).unwrap();

let root = builder.finalize().unwrap();
```

### `OrderedTrieRootEncodedBuilder`
For pre-encoded items (e.g., EIP-2718 transactions).

```rust
let mut builder = OrderedTrieRootEncodedBuilder::new(2);
builder.push(b"encoded_item_0").unwrap();
builder.push(b"encoded_item_1").unwrap();
let root = builder.finalize().unwrap();
```

## Design

- Items are pushed sequentially (0, 1, 2, ...) as they become available
- Internally buffers items in a `Vec<Option<Vec<u8>>>`
- Flushes to `HashBuilder` incrementally in the correct RLP key order (respecting `adjust_index_for_rlp` reordering)
- Requires knowing the total item count upfront (per issue: "we know how many receipts we'll receive")

## Tests

Added 11 new tests including:
- Equivalence tests vs existing `ordered_trie_root_with_encoder` for various lengths (0, 1, 2, 3, 10, 127, 128, 129, 130, 200)
- Edge cases (empty, single item, boundary at 127/128)
- Error handling (incomplete, too many items)
- Incremental flush behavior verification

Closes #118