### PR TITLE
docs: add run instructions to bench.rs

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,3 +1,7 @@
+//! Trie benchmarks.
+//!
+//! Run with: `cargo bench --features arbitrary`
+
 #![allow(missing_docs)]
 
 use alloy_trie::nodes::encode_path_leaf;


### PR DESCRIPTION
Adds a doc comment noting how to run the benchmarks with the required `arbitrary` feature.