### PR TITLE
feat(hash_builder): add `full-branch-updates` feature for storing all branch nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,10 +113,10 @@ arbitrary = [
     "nybbles/arbitrary",
 ]
 ethereum = []
-# Store all branch nodes that are referenced by hash in `updated_branch_nodes`,
-# including those with only leaf children. Required for complete incremental trie sync.
-# Without this feature, branch nodes with only leaf children are omitted as an optimization.
-complete-updates = []
+# When enabled, `HashBuilder::updated_branch_nodes` includes branch nodes even if they
+# only have leaf children (required for complete incremental trie sync). When disabled,
+# such branch nodes are omitted as an I/O optimization.
+full-branch-updates = []
 
 [[bench]]
 name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,10 @@ arbitrary = [
     "nybbles/arbitrary",
 ]
 ethereum = []
+# Store all branch nodes that are referenced by hash in `updated_branch_nodes`,
+# including those with only leaf children. Required for complete incremental trie sync.
+# Without this feature, branch nodes with only leaf children are omitted as an optimization.
+complete-updates = []
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
## Context

Builds on top of #123 to address issue reported in #25.

## Summary

Adds an opt-in `full-branch-updates` feature flag that stores all branch nodes referenced by hash in `updated_branch_nodes`, including those with only leaf children. This is required for complete incremental trie sync.

Supersedes #25.

## The Problem

The current `store_branch_node` only stores a branch if it has branch children:
```rust
let store_in_db_trie = !self.tree_masks[len].is_empty() || !self.hash_masks[len].is_empty();
```

This means branch nodes whose children are **all leaves** are omitted from updates. This is intentional as a write I/O optimization for reth, but breaks incremental sync for other consumers.

**Affected scenarios:**
- Small contracts with few storage slots
- Sparse trie regions where all children are leaves
- Fresh tries built without existing database data

## The Solution

Add a `full-branch-updates` feature flag that enables a third condition: store the branch if its parent references it as a hashed child.

```rust
#[cfg(feature = "full-branch-updates")]
{
    let parent_index = len - 1;
    let flag = TrieMask::from_nibble(current.get_unchecked(parent_index));
    has_branch_children
        || (self.hash_masks[parent_index] & flag) != TrieMask::default()
}

#[cfg(not(feature = "full-branch-updates"))]
{
    has_branch_children
}
```

**Key design decisions:**
- Uses compile-time `#[cfg]` checks - **zero runtime overhead** for the default path
- Default behavior (without feature) is unchanged - reth continues working as before
- Consumers needing complete updates opt-in via `features = ["full-branch-updates"]`

## Tests

Tests requiring the new behavior are gated behind the `full-branch-updates` feature:
- `test_updates_root` - Verifies root branch is stored for simple two-leaf trie
- `test_trie_updates_branch_nodes` - Verifies expected number of branch updates
- `test_small_storage_trie_updates` - Tests the exact failing scenario from #25
- `test_deep_divergence_empty_values` - Edge case with empty leaf values
- `test_mask_propagation_across_depths` - Multi-depth mask propagation
- `test_mask_isolation_successive_subtrees` - Verifies mask isolation across subtrees
- `arbitrary_branch_updates_complete` - Proptest verifying completeness (assertion only with feature)

## Impact

- **Not a breaking change** - default behavior is preserved
- Root hash computation is unchanged (only affects `updated_branch_nodes`)
- Consumers can opt-in when they need complete trie updates
