### PR TITLE
bench: add HashBuilder benchmarks

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,12 +1,13 @@
 #![allow(missing_docs)]
 
-use alloy_trie::nodes::encode_path_leaf;
+use alloy_primitives::{B256, keccak256};
+use alloy_trie::{HashBuilder, nodes::encode_path_leaf};
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime,
 };
 use nybbles::Nibbles;
 use proptest::{prelude::*, strategy::ValueTree};
-use std::{hint::black_box, time::Duration};
+use std::{collections::BTreeMap, hint::black_box, time::Duration};
 
 /// Benchmarks the nibble path encoding.
 pub fn nibbles_path_encoding(c: &mut Criterion) {
@@ -19,6 +20,67 @@ pub fn nibbles_path_encoding(c: &mut Criterion) {
         g.bench_function(id, |b| {
             let nibbles = &get_nibbles(len as usize);
             b.iter(|| encode_path_leaf(black_box(nibbles), false))
+        });
+    }
+}
+
+/// Benchmarks the HashBuilder with various numbers of leaves.
+pub fn hash_builder_benchmark(c: &mut Criterion) {
+    let counts = [100u64, 1000, 10000];
+
+    let mut g = group(c, "hash_builder");
+    for count in counts {
+        // Generate sorted key-value pairs
+        let data: BTreeMap<B256, Vec<u8>> = (0..count)
+            .map(|i| {
+                let key = keccak256(i.to_be_bytes());
+                let value = alloy_rlp::encode(i);
+                (key, value)
+            })
+            .collect();
+
+        g.throughput(criterion::Throughput::Elements(count));
+        let id = criterion::BenchmarkId::new("leaves", count);
+        g.bench_function(id, |b| {
+            b.iter(|| {
+                let mut hb = HashBuilder::default();
+                for (key, value) in &data {
+                    let nibbles = Nibbles::unpack(key);
+                    hb.add_leaf(nibbles, value);
+                }
+                black_box(hb.root())
+            })
+        });
+    }
+}
+
+/// Benchmarks the HashBuilder with updates enabled.
+pub fn hash_builder_with_updates(c: &mut Criterion) {
+    let counts = [100u64, 1000, 10000];
+
+    let mut g = group(c, "hash_builder_updates");
+    for count in counts {
+        let data: BTreeMap<B256, Vec<u8>> = (0..count)
+            .map(|i| {
+                let key = keccak256(i.to_be_bytes());
+                let value = alloy_rlp::encode(i);
+                (key, value)
+            })
+            .collect();
+
+        g.throughput(criterion::Throughput::Elements(count));
+        let id = criterion::BenchmarkId::new("leaves", count);
+        g.bench_function(id, |b| {
+            b.iter(|| {
+                let mut hb = HashBuilder::default().with_updates(true);
+                for (key, value) in &data {
+                    let nibbles = Nibbles::unpack(key);
+                    hb.add_leaf(nibbles, value);
+                }
+                let root = hb.root();
+                let (_, updates) = hb.split();
+                black_box((root, updates))
+            })
         });
     }
 }
@@ -37,5 +99,5 @@ fn get_nibbles(len: usize) -> Nibbles {
         .current()
 }
 
-criterion_group!(benches, nibbles_path_encoding);
+criterion_group!(benches, nibbles_path_encoding, hash_builder_benchmark, hash_builder_with_updates);
 criterion_main!(benches);


### PR DESCRIPTION
## Summary

Adds benchmarks for `HashBuilder` to enable performance tracking and comparison for future optimizations.

### Benchmarks Added

- **`hash_builder`**: Measures root computation time for tries with 100, 1000, and 10000 leaves
- **`hash_builder_updates`**: Same as above but with `with_updates(true)` to measure the overhead of tracking branch node updates

### Usage

```bash
cargo bench
```

This provides a baseline for measuring performance improvements in upcoming optimization work.