### PR TITLE
perf: manual Clone impl for RlpNode

### DIFF
--- a/src/nodes/rlp.rs
+++ b/src/nodes/rlp.rs
@@ -6,9 +6,18 @@ use core::fmt;
 const MAX: usize = 33;
 
 /// An RLP-encoded node.
-#[derive(Clone, Default, PartialEq, Eq)]
+#[derive(Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RlpNode(ArrayVec<u8, MAX>);
+
+impl Clone for RlpNode {
+    #[inline]
+    fn clone(&self) -> Self {
+        // SAFETY: `ArrayVec<u8, 33>` is `Copy`-like (contains only `u8` and a length),
+        // so we can safely copy the entire struct.
+        unsafe { core::ptr::read(self) }
+    }
+}
 
 impl alloy_rlp::Decodable for RlpNode {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {


### PR DESCRIPTION
## Summary

Replace derived `Clone` for `RlpNode` with a manual implementation using `core::ptr::read`.

## Motivation

`ArrayVec::clone` uses `iter().cloned().collect()` which is element-by-element. Since `RlpNode` wraps `ArrayVec<u8, 33>` (all bytes + a length), we can safely copy the entire struct in one shot.

## Changes

- Removed `Clone` from `RlpNode`'s derive list
- Added manual `impl Clone` using `core::ptr::read` for a single memcpy

Prompted by: danipopes