### PR TITLE
fix(proof): reject truncated exclusion proofs

### DIFF
--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -59,9 +59,11 @@ where
             process_trie_node(TrieNode::decode(&mut &node[..])?, &mut walked_path, &key)?;
     }
 
-    // Reject incomplete proofs: if the walked path is a strict prefix of the key
-    // and there is still a pending node or value, the proof was truncated.
-    if walked_path != key && key.starts_with(&walked_path) && last_decoded_node.is_some() {
+    // Reject incomplete proofs: if the walked path has not diverged from the key
+    // and there is still a pending node, the proof was truncated.
+    if key.starts_with(&walked_path)
+        && matches!(last_decoded_node, Some(NodeDecodingResult::Node(_)))
+    {
         return Err(ProofVerificationError::ValueMismatch {
             path: key,
             got: last_decoded_node.as_deref().map(Bytes::copy_from_slice),
@@ -712,6 +714,34 @@ mod tests {
         assert!(
             result.is_err(),
             "truncated proof must be rejected: walked_path must equal key before accepting any value"
+        );
+    }
+
+    #[test]
+    fn leaf_prefix_is_valid_exclusion() {
+        let leaf = TrieNode::Leaf(LeafNode::new(Nibbles::from_nibbles([0x1]), vec![0x64; 32]));
+        let mut encoded = Vec::new();
+        leaf.encode(&mut encoded);
+        let encoded = Bytes::from(encoded);
+        let root = alloy_primitives::keccak256(&encoded);
+
+        assert_eq!(verify_proof(root, Nibbles::from_nibbles([0x1, 0x2]), None, [&encoded]), Ok(()));
+    }
+
+    #[test]
+    fn truncated_proof_at_key_boundary_rejected() {
+        let child = TrieNode::Leaf(LeafNode::new(Nibbles::from_nibbles([0x0]), vec![0x64]));
+        let child = RlpNode::word_rlp(&alloy_primitives::keccak256(alloy_rlp::encode(child)));
+        let root_node =
+            TrieNode::Extension(ExtensionNode::new(Nibbles::from_nibbles([0x1, 0x2]), child));
+        let mut encoded = Vec::new();
+        root_node.encode(&mut encoded);
+        let encoded = Bytes::from(encoded);
+        let root = alloy_primitives::keccak256(&encoded);
+
+        assert!(
+            verify_proof(root, Nibbles::from_nibbles([0x1, 0x2]), None, [&encoded]).is_err(),
+            "a pending child node at the exact key boundary must not prove exclusion"
         );
     }
 

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -8,7 +8,6 @@ use crate::{
 use alloc::vec::Vec;
 use alloy_primitives::{B256, Bytes};
 use alloy_rlp::{Decodable, EMPTY_STRING_CODE};
-use core::ops::Deref;
 use nybbles::Nibbles;
 
 /// Verify the proof for given key value pair against the provided state root.
@@ -48,9 +47,13 @@ where
     for node in proof {
         // Check if the node that we just decoded (or root node, if we just started) matches
         // the expected node from the proof.
-        if Some(RlpNode::from_rlp(node).as_slice()) != last_decoded_node.as_deref() {
+        let expected_node = last_decoded_node.as_ref().and_then(NodeDecodingResult::as_node);
+        if Some(RlpNode::from_rlp(node).as_slice()) != expected_node {
             let got = Some(Bytes::copy_from_slice(node));
-            let expected = last_decoded_node.as_deref().map(Bytes::copy_from_slice);
+            let expected = last_decoded_node
+                .as_ref()
+                .map(NodeDecodingResult::as_slice)
+                .map(Bytes::copy_from_slice);
             return Err(ProofVerificationError::ValueMismatch { path: walked_path, got, expected });
         }
 
@@ -66,7 +69,10 @@ where
     {
         return Err(ProofVerificationError::ValueMismatch {
             path: key,
-            got: last_decoded_node.as_deref().map(Bytes::copy_from_slice),
+            got: last_decoded_node
+                .as_ref()
+                .map(NodeDecodingResult::as_slice)
+                .map(Bytes::copy_from_slice),
             expected: expected_value.map(Bytes::from),
         });
     }
@@ -74,12 +80,13 @@ where
     // If the walked path diverged from the key (e.g. via an extension node whose
     // key doesn't match), the key does not exist — valid exclusion.
     last_decoded_node = last_decoded_node.filter(|_| walked_path == key);
-    if last_decoded_node.as_deref() == expected_value.as_deref() {
+    let decoded_value = last_decoded_node.as_ref().map(NodeDecodingResult::as_slice);
+    if decoded_value == expected_value.as_deref() {
         Ok(())
     } else {
         Err(ProofVerificationError::ValueMismatch {
             path: key,
-            got: last_decoded_node.as_deref().map(Bytes::copy_from_slice),
+            got: decoded_value.map(Bytes::copy_from_slice),
             expected: expected_value.map(Bytes::from),
         })
     }
@@ -98,13 +105,18 @@ enum NodeDecodingResult {
     Value(Vec<u8>),
 }
 
-impl Deref for NodeDecodingResult {
-    type Target = [u8];
+impl NodeDecodingResult {
+    const fn as_node(&self) -> Option<&[u8]> {
+        match self {
+            Self::Node(node) => Some(node.as_slice()),
+            Self::Value(_) => None,
+        }
+    }
 
-    fn deref(&self) -> &Self::Target {
+    fn as_slice(&self) -> &[u8] {
         match self {
             Self::Node(node) => node.as_slice(),
-            Self::Value(value) => value,
+            Self::Value(value) => value.as_slice(),
         }
     }
 }
@@ -742,6 +754,33 @@ mod tests {
         assert!(
             verify_proof(root, Nibbles::from_nibbles([0x1, 0x2]), None, [&encoded]).is_err(),
             "a pending child node at the exact key boundary must not prove exclusion"
+        );
+    }
+
+    #[test]
+    fn node_after_terminal_leaf_rejected() {
+        let forged_value = vec![0xff; 32];
+        let forged_leaf =
+            TrieNode::Leaf(LeafNode::new(Nibbles::from_nibbles([0x2]), forged_value.clone()));
+        let forged_leaf = alloy_rlp::encode(forged_leaf);
+
+        // Make the genuine terminal value look exactly like the node reference for the forged
+        // suffix. A verifier that erases the Node/Value distinction will follow it as a child.
+        let genuine_value = RlpNode::from_rlp(&forged_leaf).as_slice().to_vec();
+        let genuine_leaf =
+            TrieNode::Leaf(LeafNode::new(Nibbles::from_nibbles([0x1]), genuine_value));
+        let genuine_leaf = Bytes::from(alloy_rlp::encode(genuine_leaf));
+        let root = alloy_primitives::keccak256(&genuine_leaf);
+
+        assert!(
+            verify_proof(
+                root,
+                Nibbles::from_nibbles([0x1, 0x2]),
+                Some(forged_value),
+                [&genuine_leaf, &Bytes::from(forged_leaf)],
+            )
+            .is_err(),
+            "proof nodes after a terminal leaf must be rejected"
         );
     }
 

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -97,7 +97,8 @@ where
 /// - [`TrieNode::Branch`] is decoded into a [`NodeDecodingResult::Value`] if the node at the
 ///   specified nibble was decoded into an in-place encoded [`TrieNode::Leaf`], or into a
 ///   [`NodeDecodingResult::Node`] otherwise.
-/// - [`TrieNode::Extension`] is always decoded into a [`NodeDecodingResult::Node`].
+/// - [`TrieNode::Extension`] is decoded into a [`NodeDecodingResult::Node`] if its child is hashed,
+///   or recursively into the result of its in-place child.
 /// - [`TrieNode::Leaf`] is always decoded into a [`NodeDecodingResult::Value`].
 #[derive(Debug, PartialEq, Eq)]
 enum NodeDecodingResult {
@@ -713,9 +714,13 @@ mod tests {
         );
 
         // Verify: full proof correctly rejects false exclusion.
-        assert!(
-            verify_proof(root, target, None, proof.iter().map(|(_, node)| node)).is_err(),
-            "full proof must reject exclusion of an existing key"
+        assert_eq!(
+            verify_proof(root, target, None, proof.iter().map(|(_, node)| node)),
+            Err(ProofVerificationError::ValueMismatch {
+                path: target,
+                got: Some(Bytes::copy_from_slice(&target_value[..])),
+                expected: None,
+            })
         );
 
         // Test: truncated proof to only the first node (root) must be rejected.
@@ -724,8 +729,15 @@ mod tests {
 
         let result = verify_proof(root, target, None, truncated.iter().copied());
         assert!(
-            result.is_err(),
-            "truncated proof must be rejected: walked_path must equal key before accepting any value"
+            matches!(
+                result,
+                Err(ProofVerificationError::ValueMismatch {
+                    path,
+                    got: Some(_),
+                    expected: None,
+                }) if path == target
+            ),
+            "truncated proof must be rejected while a child node is pending"
         );
     }
 
@@ -744,16 +756,22 @@ mod tests {
     fn truncated_proof_at_key_boundary_rejected() {
         let child = TrieNode::Leaf(LeafNode::new(Nibbles::from_nibbles([0x0]), vec![0x64]));
         let child = RlpNode::word_rlp(&alloy_primitives::keccak256(alloy_rlp::encode(child)));
+        let pending_child = Bytes::copy_from_slice(child.as_slice());
         let root_node =
             TrieNode::Extension(ExtensionNode::new(Nibbles::from_nibbles([0x1, 0x2]), child));
         let mut encoded = Vec::new();
         root_node.encode(&mut encoded);
         let encoded = Bytes::from(encoded);
         let root = alloy_primitives::keccak256(&encoded);
+        let key = Nibbles::from_nibbles([0x1, 0x2]);
 
-        assert!(
-            verify_proof(root, Nibbles::from_nibbles([0x1, 0x2]), None, [&encoded]).is_err(),
-            "a pending child node at the exact key boundary must not prove exclusion"
+        assert_eq!(
+            verify_proof(root, key, Some(pending_child.to_vec()), [&encoded]),
+            Err(ProofVerificationError::ValueMismatch {
+                path: key,
+                got: Some(pending_child.clone()),
+                expected: Some(pending_child),
+            })
         );
     }
 
@@ -762,25 +780,28 @@ mod tests {
         let forged_value = vec![0xff; 32];
         let forged_leaf =
             TrieNode::Leaf(LeafNode::new(Nibbles::from_nibbles([0x2]), forged_value.clone()));
-        let forged_leaf = alloy_rlp::encode(forged_leaf);
+        let forged_leaf = Bytes::from(alloy_rlp::encode(forged_leaf));
 
         // Make the genuine terminal value look exactly like the node reference for the forged
         // suffix. A verifier that erases the Node/Value distinction will follow it as a child.
-        let genuine_value = RlpNode::from_rlp(&forged_leaf).as_slice().to_vec();
+        let genuine_value = Bytes::copy_from_slice(RlpNode::from_rlp(&forged_leaf).as_slice());
         let genuine_leaf =
-            TrieNode::Leaf(LeafNode::new(Nibbles::from_nibbles([0x1]), genuine_value));
+            TrieNode::Leaf(LeafNode::new(Nibbles::from_nibbles([0x1]), genuine_value.to_vec()));
         let genuine_leaf = Bytes::from(alloy_rlp::encode(genuine_leaf));
         let root = alloy_primitives::keccak256(&genuine_leaf);
 
-        assert!(
+        assert_eq!(
             verify_proof(
                 root,
                 Nibbles::from_nibbles([0x1, 0x2]),
                 Some(forged_value),
-                [&genuine_leaf, &Bytes::from(forged_leaf)],
-            )
-            .is_err(),
-            "proof nodes after a terminal leaf must be rejected"
+                [&genuine_leaf, &forged_leaf],
+            ),
+            Err(ProofVerificationError::ValueMismatch {
+                path: Nibbles::from_nibbles([0x1]),
+                got: Some(forged_leaf),
+                expected: Some(genuine_value),
+            })
         );
     }
 


### PR DESCRIPTION
## Problem

`proof::verify_proof` accepted two kinds of invalid proofs:

1. A truncated proof could be accepted as exclusion when verification stopped with a pending child node.
2. A terminal leaf value could be treated as a child-node reference, allowing appended forged nodes to replace the verified value.

## Fix

Keep pending child nodes distinct from terminal values.

- Reject proofs that end while a child node is still required.
- Reject any proof node supplied after reaching a terminal value.
- Preserve valid exclusions where the queried path diverges or extends beyond an existing leaf.

Closes OSS-706
