### PR TITLE
perf(proof): reduce size of ProofVerificationError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ all = { level = "warn", priority = -1 }
 missing-const-for-fn = "warn"
 use-self = "warn"
 redundant-clone = "warn"
-result_large_err = "allow"
+result_large_err = "warn"
 
 # Use the `--profile profiling` flag to show symbols in release mode.
 # e.g. `cargo build --profile profiling`

--- a/src/proof/error.rs
+++ b/src/proof/error.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use alloy_primitives::{B256, Bytes};
 use nybbles::Nibbles;
 
@@ -5,27 +6,51 @@ use nybbles::Nibbles;
 #[derive(PartialEq, Eq, Debug, thiserror::Error)]
 pub enum ProofVerificationError {
     /// State root does not match the expected.
-    #[error("root mismatch. got: {got}. expected: {expected}")]
-    RootMismatch {
-        /// Computed state root.
-        got: B256,
-        /// State root provided to verify function.
-        expected: B256,
-    },
+    #[error(transparent)]
+    RootMismatch(Box<RootMismatchError>),
     /// The node value does not match at specified path.
-    #[error("value mismatch at path {path:?}. got: {got:?}. expected: {expected:?}")]
-    ValueMismatch {
-        /// Path at which error occurred.
-        path: Nibbles,
-        /// Value in the proof.
-        got: Option<Bytes>,
-        /// Expected value.
-        expected: Option<Bytes>,
-    },
+    #[error(transparent)]
+    ValueMismatch(Box<ValueMismatchError>),
     /// Encountered unexpected empty root node.
     #[error("unexpected empty root node")]
     UnexpectedEmptyRoot,
     /// Error during RLP decoding of trie node.
     #[error(transparent)]
     Rlp(#[from] alloy_rlp::Error),
+}
+
+/// State root does not match the expected.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, thiserror::Error)]
+#[error("root mismatch. got: {got}. expected: {expected}")]
+pub struct RootMismatchError {
+    /// Computed state root.
+    pub got: B256,
+    /// State root provided to verify function.
+    pub expected: B256,
+}
+
+/// The node value does not match at specified path.
+#[derive(PartialEq, Eq, Debug, thiserror::Error)]
+#[error("value mismatch at path {path:?}. got: {got:?}. expected: {expected:?}")]
+pub struct ValueMismatchError {
+    /// Path at which error occurred.
+    pub path: Nibbles,
+    /// Value in the proof.
+    pub got: Option<Bytes>,
+    /// Expected value.
+    pub expected: Option<Bytes>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_size() {
+        let size = core::mem::size_of::<ProofVerificationError>();
+        eprintln!("ProofVerificationError size: {size} bytes");
+        // Down from 112 bytes to 24 after boxing both large variants. (The error was
+        // 144 bytes when #89 was filed; nybbles 0.4 had already shrunk `Nibbles` since.)
+        assert!(size <= 24, "ProofVerificationError is {size} bytes, should be <= 24");
+    }
 }

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -7,7 +7,7 @@ mod verify;
 pub use verify::verify_proof;
 
 mod error;
-pub use error::ProofVerificationError;
+pub use error::{ProofVerificationError, RootMismatchError, ValueMismatchError};
 
 mod decoded_proof_nodes;
 pub use decoded_proof_nodes::DecodedProofNodes;


### PR DESCRIPTION
Closes #89

Box the `RootMismatch` and `ValueMismatch` variants to shrink `ProofVerificationError` from 112 to 24 bytes (`Result<(), ProofVerificationError>` follows suit). The error was 144 bytes when #89 was filed; the nybbles 0.4 upgrade had already brought it down to 112 since, this PR takes care of the rest. `#[error(transparent)]` keeps the Display output identical.

Re-enables clippy `result_large_err` as a warning instead of `allow`; the new size passes with a wide margin.

Breaking change: `RootMismatch` and `ValueMismatch` become single-field tuple variants wrapping the boxed `RootMismatchError` / `ValueMismatchError` structs, so downstream code matching on the old struct fields needs updating.
