### PR TITLE
feat: support extended trie accounts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ proptest = { version = "1.5", optional = true }
 proptest-derive = { version = "0.7", optional = true }
 
 [dev-dependencies]
+rmp-serde = "1.3"
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 serde_json = "1.0"
 hash-db = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ debug = "full"
 strip = "none"
 
 [dependencies]
+borsh = { version = "1.5", default-features = false, optional = true }
+triomphe = { version = "0.1.16", default-features = false, optional = true }
 alloy-primitives = { version = "1.0", default-features = false, features = [
     "rlp",
     "map",
@@ -89,6 +91,8 @@ triehash = "0.8.4"
 criterion = { version = "4.3", package = "codspeed-criterion-compat" }
 
 [features]
+borsh = ["dep:borsh"]
+account-ext = ["dep:triomphe"]
 default = ["std", "alloy-primitives/default"]
 std = [
     "alloy-primitives/std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ proptest = { version = "1.5", optional = true }
 proptest-derive = { version = "0.7", optional = true }
 
 [dev-dependencies]
-bincode = "1.3"
+postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 serde_json = "1.0"
 hash-db = "0.15"
 plain_hasher = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,8 @@ proptest = { version = "1.5", optional = true }
 proptest-derive = { version = "0.7", optional = true }
 
 [dev-dependencies]
+bincode = "1.3"
+serde_json = "1.0"
 hash-db = "0.15"
 plain_hasher = "0.2"
 triehash = "0.8.4"

--- a/src/account.rs
+++ b/src/account.rs
@@ -128,7 +128,7 @@ impl<E: TrieAccountExtension> Encodable for TrieAccount<E> {
     }
 }
 
-impl<E: TrieAccountExtension> Decodable for TrieAccount<E> {
+impl<E: TrieAccountExtension + Default> Decodable for TrieAccount<E> {
     fn decode(buf: &mut &[u8]) -> Result<Self> {
         let header = Header::decode(buf)?;
         if !header.list {
@@ -142,7 +142,11 @@ impl<E: TrieAccountExtension> Decodable for TrieAccount<E> {
             balance: Decodable::decode(&mut payload)?,
             storage_root: Decodable::decode(&mut payload)?,
             code_hash: Decodable::decode(&mut payload)?,
-            extension: E::decode_payload(&mut payload)?,
+            extension: if payload.is_empty() {
+                E::default()
+            } else {
+                E::decode_payload(&mut payload)?
+            },
         };
         if !payload.is_empty() {
             return Err(Error::UnexpectedLength);
@@ -231,6 +235,10 @@ mod tests {
         });
         assert_eq!(alloy_rlp::encode(account), expected);
         assert_eq!(TrieAccount::<()>::decode(&mut expected.as_slice()).unwrap(), account);
+        assert_eq!(
+            TrieAccount::<TestExtension>::decode(&mut expected.as_slice()).unwrap().extension,
+            TestExtension::default()
+        );
     }
 
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/src/account.rs
+++ b/src/account.rs
@@ -8,7 +8,7 @@ use alloy_rlp::{BufMut, Decodable, Encodable, Error, Header, Result};
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(not(feature = "account-ext"), derive(Copy))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct TrieAccount {
     /// The account's nonce.
@@ -21,35 +21,12 @@ pub struct TrieAccount {
     /// The hash of the code of the account.
     pub code_hash: B256,
     /// Raw chain-specific bytes, encoded as a fifth RLP string only when nonempty.
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "AccountExtension::is_empty")
+    )]
     #[cfg(feature = "account-ext")]
     pub extension: AccountExtension,
-}
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for TrieAccount {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-
-        #[cfg(feature = "account-ext")]
-        let include_extension = !serializer.is_human_readable() || !self.extension.is_empty();
-        #[cfg(not(feature = "account-ext"))]
-        let include_extension = false;
-        let mut state =
-            serializer.serialize_struct("TrieAccount", 4 + usize::from(include_extension))?;
-        state.serialize_field("nonce", &alloy_primitives::U64::from(self.nonce))?;
-        state.serialize_field("balance", &self.balance)?;
-        state.serialize_field("storageRoot", &self.storage_root)?;
-        state.serialize_field("codeHash", &self.code_hash)?;
-        #[cfg(feature = "account-ext")]
-        if include_extension {
-            state.serialize_field("extension", &self.extension)?;
-        }
-        state.end()
-    }
 }
 
 impl Default for TrieAccount {
@@ -141,7 +118,11 @@ impl Decodable for TrieAccount {
 #[cfg(feature = "serde")]
 mod quantity {
     use alloy_primitives::U64;
-    use serde::{Deserialize, Deserializer};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub(crate) fn serialize<S: Serializer>(value: &u64, serializer: S) -> Result<S::Ok, S::Error> {
+        U64::from(*value).serialize(serializer)
+    }
 
     /// Deserializes a primitive number from a "quantity" hex string.
     pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
@@ -158,7 +139,10 @@ mod tests {
     use alloy_rlp::RlpEncodable;
 
     #[derive(RlpEncodable)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     struct LegacyAccount {
+        #[cfg_attr(feature = "serde", serde(with = "quantity"))]
         nonce: u64,
         balance: U256,
         storage_root: B256,
@@ -178,6 +162,38 @@ mod tests {
         assert_eq!(encoded, alloy_rlp::encode(legacy));
         assert_eq!(encoded.len(), account.length());
         assert_eq!(TrieAccount::decode(&mut encoded.as_slice()).unwrap(), account);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn account_messagepack_compatibility() {
+        let account = TrieAccount { nonce: 7, balance: U256::from(42), ..Default::default() };
+        let legacy = LegacyAccount {
+            nonce: account.nonce,
+            balance: account.balance,
+            storage_root: account.storage_root,
+            code_hash: account.code_hash,
+        };
+        let encoded = rmp_serde::to_vec(&account).unwrap();
+        assert_eq!(encoded, rmp_serde::to_vec(&legacy).unwrap());
+        assert_eq!(rmp_serde::from_slice::<TrieAccount>(&encoded).unwrap(), account);
+        let decoded: LegacyAccount = rmp_serde::from_slice(&encoded).unwrap();
+        assert_eq!(rmp_serde::to_vec(&decoded).unwrap(), encoded);
+
+        let accounts = alloc::vec![
+            account,
+            TrieAccount {
+                nonce: 9,
+                #[cfg(feature = "account-ext")]
+                extension: AccountExtension::copy_from_slice(&[0x82, 0xaa]),
+                ..Default::default()
+            },
+            TrieAccount::default(),
+        ];
+        let record = (accounts, 99u64);
+        let encoded = rmp_serde::to_vec(&record).unwrap();
+        let decoded: (alloc::vec::Vec<TrieAccount>, u64) = rmp_serde::from_slice(&encoded).unwrap();
+        assert_eq!(decoded, record);
     }
 
     #[cfg(feature = "account-ext")]

--- a/src/account.rs
+++ b/src/account.rs
@@ -20,7 +20,7 @@ pub struct TrieAccount {
     pub storage_root: B256,
     /// The hash of the code of the account.
     pub code_hash: B256,
-    /// Chain-specific fields committed to by this account leaf.
+    /// Raw chain-specific bytes, encoded as a fifth RLP string only when nonempty.
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg(feature = "account-ext")]
     pub extension: AccountExtension,
@@ -79,14 +79,17 @@ impl Encodable for TrieAccount {
             + self.storage_root.length()
             + self.code_hash.length();
         #[cfg(feature = "account-ext")]
-        let payload_length = payload_length + self.extension.len();
+        let payload_length = payload_length
+            + if self.extension.is_empty() { 0 } else { self.extension.as_ref().length() };
         Header { list: true, payload_length }.encode(out);
         self.nonce.encode(out);
         self.balance.encode(out);
         self.storage_root.encode(out);
         self.code_hash.encode(out);
         #[cfg(feature = "account-ext")]
-        out.put_slice(&self.extension);
+        if !self.extension.is_empty() {
+            self.extension.as_ref().encode(out);
+        }
     }
 
     fn length(&self) -> usize {
@@ -95,7 +98,8 @@ impl Encodable for TrieAccount {
             + self.storage_root.length()
             + self.code_hash.length();
         #[cfg(feature = "account-ext")]
-        let payload_length = payload_length + self.extension.len();
+        let payload_length = payload_length
+            + if self.extension.is_empty() { 0 } else { self.extension.as_ref().length() };
         Header { list: true, payload_length }.length() + payload_length
     }
 }
@@ -116,12 +120,15 @@ impl Decodable for TrieAccount {
             code_hash: Decodable::decode(&mut payload)?,
             #[cfg(feature = "account-ext")]
             extension: {
-                let extension = AccountExtension::copy_from_slice(payload);
-                // Preserve complete trailing RLP items, not an extra byte-string wrapper.
-                while !payload.is_empty() {
-                    alloy_rlp::Header::decode_raw(&mut payload)?;
+                if payload.is_empty() {
+                    AccountExtension::default()
+                } else {
+                    let bytes = Header::decode_bytes(&mut payload, false)?;
+                    if bytes.is_empty() {
+                        return Err(Error::Custom("empty account extension must be omitted"));
+                    }
+                    AccountExtension::copy_from_slice(bytes)
                 }
-                extension
             },
         };
         if !payload.is_empty() {
@@ -175,13 +182,13 @@ mod tests {
 
     #[cfg(feature = "account-ext")]
     #[test]
-    fn extension_is_appended_verbatim() {
+    fn extension_is_encoded_as_one_string() {
         let account = TrieAccount {
             extension: AccountExtension::copy_from_slice(&[0x01, 0x82, 0xaa, 0xbb]),
             ..Default::default()
         };
         let encoded = alloy_rlp::encode(&account);
-        assert!(encoded.ends_with(&[0x01, 0x82, 0xaa, 0xbb]));
+        assert!(encoded.ends_with(&[0x84, 0x01, 0x82, 0xaa, 0xbb]));
         assert_eq!(encoded.len(), account.length());
         assert_eq!(TrieAccount::decode(&mut encoded.as_slice()).unwrap(), account);
         assert_ne!(account.trie_hash_slow(), TrieAccount::default().trie_hash_slow());
@@ -189,11 +196,30 @@ mod tests {
 
     #[cfg(feature = "account-ext")]
     #[test]
-    fn malformed_extension_is_rejected() {
+    fn arbitrary_extension_bytes_roundtrip() {
         let account = TrieAccount {
             extension: AccountExtension::copy_from_slice(&[0x82, 0xaa]),
             ..Default::default()
         };
-        assert!(TrieAccount::decode(&mut alloy_rlp::encode(account).as_slice()).is_err());
+        let encoded = alloy_rlp::encode(&account);
+        assert!(encoded.ends_with(&[0x82, 0x82, 0xaa]));
+        assert_eq!(TrieAccount::decode(&mut encoded.as_slice()).unwrap(), account);
+    }
+
+    #[cfg(feature = "account-ext")]
+    #[test]
+    fn extension_must_be_one_nonempty_string() {
+        let account = TrieAccount::default();
+        for suffix in [&[0x80][..], &[0xc0][..], &[0x01, 0x02][..], &[0x82, 0xaa][..]] {
+            let encoded = alloy_rlp::encode(&account);
+            let mut input = encoded.as_slice();
+            let header = Header::decode(&mut input).unwrap();
+            let mut invalid = alloc::vec::Vec::new();
+            Header { list: true, payload_length: header.payload_length + suffix.len() }
+                .encode(&mut invalid);
+            invalid.extend_from_slice(input);
+            invalid.extend_from_slice(suffix);
+            assert!(alloy_rlp::decode_exact::<TrieAccount>(&invalid).is_err());
+        }
     }
 }

--- a/src/account.rs
+++ b/src/account.rs
@@ -5,8 +5,9 @@ use alloy_rlp::{BufMut, Decodable, Encodable, Error, Header, Result};
 /// Represents an TrieAccount in the account trie.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(bound(deserialize = "E: serde::Deserialize<'de> + Default")))]
 pub struct TrieAccount<E = ()> {
     /// The account's nonce.
     #[cfg_attr(feature = "serde", serde(with = "quantity"))]
@@ -20,6 +21,36 @@ pub struct TrieAccount<E = ()> {
     /// Chain-specific fields committed to by this account leaf.
     #[cfg_attr(feature = "serde", serde(default))]
     pub extension: E,
+}
+
+#[cfg(feature = "serde")]
+fn is_default<T: Default + PartialEq>(value: &T) -> bool {
+    value == &T::default()
+}
+
+#[cfg(feature = "serde")]
+impl<E> serde::Serialize for TrieAccount<E>
+where
+    E: serde::Serialize + Default + PartialEq,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let include_extension = !serializer.is_human_readable() || !is_default(&self.extension);
+        let mut state =
+            serializer.serialize_struct("TrieAccount", 4 + usize::from(include_extension))?;
+        state.serialize_field("nonce", &alloy_primitives::U64::from(self.nonce))?;
+        state.serialize_field("balance", &self.balance)?;
+        state.serialize_field("storageRoot", &self.storage_root)?;
+        state.serialize_field("codeHash", &self.code_hash)?;
+        if include_extension {
+            state.serialize_field("extension", &self.extension)?;
+        }
+        state.end()
+    }
 }
 
 impl<E: Default> Default for TrieAccount<E> {

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,13 +1,13 @@
 use crate::{EMPTY_ROOT_HASH, KECCAK_EMPTY};
 use alloy_primitives::{B256, U256, keccak256};
-use alloy_rlp::{RlpDecodable, RlpEncodable};
+use alloy_rlp::{BufMut, Decodable, Encodable, Error, Header, Result};
 
 /// Represents an TrieAccount in the account trie.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, RlpDecodable, RlpEncodable)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct TrieAccount {
+pub struct TrieAccount<E = ()> {
     /// The account's nonce.
     #[cfg_attr(feature = "serde", serde(with = "quantity"))]
     pub nonce: u64,
@@ -17,23 +17,106 @@ pub struct TrieAccount {
     pub storage_root: B256,
     /// The hash of the code of the account.
     pub code_hash: B256,
+    /// Chain-specific fields committed to by this account leaf.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub extension: E,
 }
 
-impl Default for TrieAccount {
+impl<E: Default> Default for TrieAccount<E> {
     fn default() -> Self {
         Self {
             nonce: 0,
             balance: U256::ZERO,
             storage_root: EMPTY_ROOT_HASH,
             code_hash: KECCAK_EMPTY,
+            extension: E::default(),
         }
     }
 }
 
-impl TrieAccount {
+impl<E: TrieAccountExtension> TrieAccount<E> {
     /// Compute  hash as committed to in the MPT trie without memorizing.
     pub fn trie_hash_slow(&self) -> B256 {
         keccak256(alloy_rlp::encode(self))
+    }
+}
+
+/// Additional chain-specific fields appended to an account trie leaf's RLP list.
+///
+/// Implementations encode zero or more complete RLP items. The unit type encodes no items, so
+/// The unit implementation emits no fields, so [`TrieAccount<()>`] is byte-for-byte compatible
+/// with the canonical four-field Ethereum account encoding.
+pub trait TrieAccountExtension: Sized {
+    /// Returns the encoded length of all extension fields.
+    fn payload_length(&self) -> usize;
+
+    /// Appends all extension fields to an account RLP list payload.
+    fn encode_payload(&self, out: &mut dyn BufMut);
+
+    /// Decodes the extension fields from the remaining account RLP list payload.
+    fn decode_payload(payload: &mut &[u8]) -> Result<Self>;
+}
+
+impl TrieAccountExtension for () {
+    #[inline]
+    fn payload_length(&self) -> usize {
+        0
+    }
+
+    #[inline]
+    fn encode_payload(&self, _out: &mut dyn BufMut) {}
+
+    #[inline]
+    fn decode_payload(_payload: &mut &[u8]) -> Result<Self> {
+        Ok(())
+    }
+}
+
+impl<E: TrieAccountExtension> Encodable for TrieAccount<E> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        let payload_length = self.nonce.length()
+            + self.balance.length()
+            + self.storage_root.length()
+            + self.code_hash.length()
+            + self.extension.payload_length();
+        Header { list: true, payload_length }.encode(out);
+        self.nonce.encode(out);
+        self.balance.encode(out);
+        self.storage_root.encode(out);
+        self.code_hash.encode(out);
+        self.extension.encode_payload(out);
+    }
+
+    fn length(&self) -> usize {
+        let payload_length = self.nonce.length()
+            + self.balance.length()
+            + self.storage_root.length()
+            + self.code_hash.length()
+            + self.extension.payload_length();
+        Header { list: true, payload_length }.length() + payload_length
+    }
+}
+
+impl<E: TrieAccountExtension> Decodable for TrieAccount<E> {
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(Error::UnexpectedString);
+        }
+
+        let (mut payload, rest) = buf.split_at(header.payload_length);
+        *buf = rest;
+        let account = Self {
+            nonce: Decodable::decode(&mut payload)?,
+            balance: Decodable::decode(&mut payload)?,
+            storage_root: Decodable::decode(&mut payload)?,
+            code_hash: Decodable::decode(&mut payload)?,
+            extension: E::decode_payload(&mut payload)?,
+        };
+        if !payload.is_empty() {
+            return Err(Error::UnexpectedLength);
+        }
+        Ok(account)
     }
 }
 
@@ -63,7 +146,15 @@ mod quantity {
 mod tests {
     use super::*;
     use alloy_primitives::{U256, hex};
-    use alloy_rlp::Decodable;
+    use alloy_rlp::{Decodable, RlpEncodable};
+
+    #[derive(RlpEncodable)]
+    struct LegacyTrieAccount {
+        nonce: u64,
+        balance: U256,
+        storage_root: B256,
+        code_hash: B256,
+    }
 
     #[test]
     fn test_account_encoding() {
@@ -74,6 +165,7 @@ mod tests {
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             )),
             code_hash: keccak256(hex!("5a465a905090036002900360015500")),
+            extension: (),
         };
 
         let encoded = alloy_rlp::encode(account);
@@ -91,10 +183,55 @@ mod tests {
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             )),
             code_hash: keccak256(hex!("5a465a905090036002900360015500")),
+            extension: (),
         };
 
         let expected_hash = keccak256(alloy_rlp::encode(account));
         let actual_hash = account.trie_hash_slow();
         assert_eq!(expected_hash, actual_hash);
+    }
+
+    #[test]
+    fn empty_extension_preserves_account_encoding() {
+        let account = TrieAccount {
+            nonce: 1,
+            balance: U256::from(1000),
+            storage_root: B256::repeat_byte(0xaa),
+            code_hash: B256::repeat_byte(0xbb),
+            extension: (),
+        };
+        let expected = alloy_rlp::encode(LegacyTrieAccount {
+            nonce: account.nonce,
+            balance: account.balance,
+            storage_root: account.storage_root,
+            code_hash: account.code_hash,
+        });
+        assert_eq!(alloy_rlp::encode(account), expected);
+        assert_eq!(TrieAccount::<()>::decode(&mut expected.as_slice()).unwrap(), account);
+    }
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    struct TestExtension(u64);
+
+    impl TrieAccountExtension for TestExtension {
+        fn payload_length(&self) -> usize {
+            self.0.length()
+        }
+
+        fn encode_payload(&self, out: &mut dyn BufMut) {
+            self.0.encode(out);
+        }
+
+        fn decode_payload(payload: &mut &[u8]) -> Result<Self> {
+            u64::decode(payload).map(Self)
+        }
+    }
+
+    #[test]
+    fn extended_account_roundtrip() {
+        let account = TrieAccount { extension: TestExtension(42), ..Default::default() };
+        let encoded = alloy_rlp::encode(account);
+
+        assert_eq!(TrieAccount::decode(&mut encoded.as_slice()).unwrap(), account);
     }
 }

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,14 +1,16 @@
+#[cfg(feature = "account-ext")]
+use crate::AccountExtension;
 use crate::{EMPTY_ROOT_HASH, KECCAK_EMPTY};
 use alloy_primitives::{B256, U256, keccak256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Error, Header, Result};
 
 /// Represents an TrieAccount in the account trie.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(not(feature = "account-ext"), derive(Copy))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-#[cfg_attr(feature = "serde", serde(bound(deserialize = "E: serde::Deserialize<'de> + Default")))]
-pub struct TrieAccount<E = ()> {
+pub struct TrieAccount {
     /// The account's nonce.
     #[cfg_attr(feature = "serde", serde(with = "quantity"))]
     pub nonce: u64,
@@ -20,32 +22,29 @@ pub struct TrieAccount<E = ()> {
     pub code_hash: B256,
     /// Chain-specific fields committed to by this account leaf.
     #[cfg_attr(feature = "serde", serde(default))]
-    pub extension: E,
+    #[cfg(feature = "account-ext")]
+    pub extension: AccountExtension,
 }
 
 #[cfg(feature = "serde")]
-fn is_default<T: Default + PartialEq>(value: &T) -> bool {
-    value == &T::default()
-}
-
-#[cfg(feature = "serde")]
-impl<E> serde::Serialize for TrieAccount<E>
-where
-    E: serde::Serialize + Default + PartialEq,
-{
+impl serde::Serialize for TrieAccount {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         use serde::ser::SerializeStruct;
 
-        let include_extension = !serializer.is_human_readable() || !is_default(&self.extension);
+        #[cfg(feature = "account-ext")]
+        let include_extension = !serializer.is_human_readable() || !self.extension.is_empty();
+        #[cfg(not(feature = "account-ext"))]
+        let include_extension = false;
         let mut state =
             serializer.serialize_struct("TrieAccount", 4 + usize::from(include_extension))?;
         state.serialize_field("nonce", &alloy_primitives::U64::from(self.nonce))?;
         state.serialize_field("balance", &self.balance)?;
         state.serialize_field("storageRoot", &self.storage_root)?;
         state.serialize_field("codeHash", &self.code_hash)?;
+        #[cfg(feature = "account-ext")]
         if include_extension {
             state.serialize_field("extension", &self.extension)?;
         }
@@ -53,85 +52,55 @@ where
     }
 }
 
-impl<E: Default> Default for TrieAccount<E> {
+impl Default for TrieAccount {
     fn default() -> Self {
         Self {
             nonce: 0,
             balance: U256::ZERO,
             storage_root: EMPTY_ROOT_HASH,
             code_hash: KECCAK_EMPTY,
-            extension: E::default(),
+            #[cfg(feature = "account-ext")]
+            extension: AccountExtension::default(),
         }
     }
 }
 
-impl<E: TrieAccountExtension> TrieAccount<E> {
+impl TrieAccount {
     /// Compute  hash as committed to in the MPT trie without memorizing.
     pub fn trie_hash_slow(&self) -> B256 {
         keccak256(alloy_rlp::encode(self))
     }
 }
 
-/// Additional chain-specific fields appended to an account trie leaf's RLP list.
-///
-/// Implementations encode zero or more complete RLP items. The unit implementation emits no
-/// fields, so [`TrieAccount<()>`] is byte-for-byte compatible
-/// with the canonical four-field Ethereum account encoding.
-pub trait TrieAccountExtension: Sized {
-    /// Returns the encoded length of all extension fields.
-    fn payload_length(&self) -> usize;
-
-    /// Appends all extension fields to an account RLP list payload.
-    ///
-    /// Must write exactly [`Self::payload_length`] bytes. Callers may provide a fixed-size
-    /// buffer to encode directly into shared storage without an intermediate allocation.
-    fn encode_payload(&self, out: &mut dyn BufMut);
-
-    /// Decodes the extension fields from the remaining account RLP list payload.
-    fn decode_payload(payload: &mut &[u8]) -> Result<Self>;
-}
-
-impl TrieAccountExtension for () {
-    #[inline]
-    fn payload_length(&self) -> usize {
-        0
-    }
-
-    #[inline]
-    fn encode_payload(&self, _out: &mut dyn BufMut) {}
-
-    #[inline]
-    fn decode_payload(_payload: &mut &[u8]) -> Result<Self> {
-        Ok(())
-    }
-}
-
-impl<E: TrieAccountExtension> Encodable for TrieAccount<E> {
+impl Encodable for TrieAccount {
     fn encode(&self, out: &mut dyn BufMut) {
         let payload_length = self.nonce.length()
             + self.balance.length()
             + self.storage_root.length()
-            + self.code_hash.length()
-            + self.extension.payload_length();
+            + self.code_hash.length();
+        #[cfg(feature = "account-ext")]
+        let payload_length = payload_length + self.extension.len();
         Header { list: true, payload_length }.encode(out);
         self.nonce.encode(out);
         self.balance.encode(out);
         self.storage_root.encode(out);
         self.code_hash.encode(out);
-        self.extension.encode_payload(out);
+        #[cfg(feature = "account-ext")]
+        out.put_slice(&self.extension);
     }
 
     fn length(&self) -> usize {
         let payload_length = self.nonce.length()
             + self.balance.length()
             + self.storage_root.length()
-            + self.code_hash.length()
-            + self.extension.payload_length();
+            + self.code_hash.length();
+        #[cfg(feature = "account-ext")]
+        let payload_length = payload_length + self.extension.len();
         Header { list: true, payload_length }.length() + payload_length
     }
 }
 
-impl<E: TrieAccountExtension + Default> Decodable for TrieAccount<E> {
+impl Decodable for TrieAccount {
     fn decode(buf: &mut &[u8]) -> Result<Self> {
         let header = Header::decode(buf)?;
         if !header.list {
@@ -145,10 +114,14 @@ impl<E: TrieAccountExtension + Default> Decodable for TrieAccount<E> {
             balance: Decodable::decode(&mut payload)?,
             storage_root: Decodable::decode(&mut payload)?,
             code_hash: Decodable::decode(&mut payload)?,
-            extension: if payload.is_empty() {
-                E::default()
-            } else {
-                E::decode_payload(&mut payload)?
+            #[cfg(feature = "account-ext")]
+            extension: {
+                let extension = AccountExtension::copy_from_slice(payload);
+                // Preserve complete trailing RLP items, not an extra byte-string wrapper.
+                while !payload.is_empty() {
+                    alloy_rlp::Header::decode_raw(&mut payload)?;
+                }
+                extension
             },
         };
         if !payload.is_empty() {
@@ -175,11 +148,10 @@ mod quantity {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{U256, hex};
-    use alloy_rlp::{Decodable, RlpEncodable};
+    use alloy_rlp::RlpEncodable;
 
     #[derive(RlpEncodable)]
-    struct LegacyTrieAccount {
+    struct LegacyAccount {
         nonce: u64,
         balance: U256,
         storage_root: B256,
@@ -187,85 +159,41 @@ mod tests {
     }
 
     #[test]
-    fn test_account_encoding() {
-        let account = TrieAccount {
-            nonce: 1,
-            balance: U256::from(1000),
-            storage_root: B256::from_slice(&hex!(
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            )),
-            code_hash: keccak256(hex!("5a465a905090036002900360015500")),
-            extension: (),
-        };
-
-        let encoded = alloy_rlp::encode(account);
-
-        let decoded = TrieAccount::decode(&mut &encoded[..]).unwrap();
-        assert_eq!(account, decoded);
-    }
-
-    #[test]
-    fn test_trie_hash_slow() {
-        let account = TrieAccount {
-            nonce: 1,
-            balance: U256::from(1000),
-            storage_root: B256::from_slice(&hex!(
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            )),
-            code_hash: keccak256(hex!("5a465a905090036002900360015500")),
-            extension: (),
-        };
-
-        let expected_hash = keccak256(alloy_rlp::encode(account));
-        let actual_hash = account.trie_hash_slow();
-        assert_eq!(expected_hash, actual_hash);
-    }
-
-    #[test]
-    fn empty_extension_preserves_account_encoding() {
-        let account = TrieAccount {
-            nonce: 1,
-            balance: U256::from(1000),
-            storage_root: B256::repeat_byte(0xaa),
-            code_hash: B256::repeat_byte(0xbb),
-            extension: (),
-        };
-        let expected = alloy_rlp::encode(LegacyTrieAccount {
+    fn empty_extension_preserves_rlp() {
+        let account = TrieAccount { nonce: 7, balance: U256::from(42), ..Default::default() };
+        let legacy = LegacyAccount {
             nonce: account.nonce,
             balance: account.balance,
             storage_root: account.storage_root,
             code_hash: account.code_hash,
-        });
-        assert_eq!(alloy_rlp::encode(account), expected);
-        assert_eq!(TrieAccount::<()>::decode(&mut expected.as_slice()).unwrap(), account);
-        assert_eq!(
-            TrieAccount::<TestExtension>::decode(&mut expected.as_slice()).unwrap().extension,
-            TestExtension::default()
-        );
-    }
-
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-    struct TestExtension(u64);
-
-    impl TrieAccountExtension for TestExtension {
-        fn payload_length(&self) -> usize {
-            self.0.length()
-        }
-
-        fn encode_payload(&self, out: &mut dyn BufMut) {
-            self.0.encode(out);
-        }
-
-        fn decode_payload(payload: &mut &[u8]) -> Result<Self> {
-            u64::decode(payload).map(Self)
-        }
-    }
-
-    #[test]
-    fn extended_account_roundtrip() {
-        let account = TrieAccount { extension: TestExtension(42), ..Default::default() };
-        let encoded = alloy_rlp::encode(account);
-
+        };
+        let encoded = alloy_rlp::encode(&account);
+        assert_eq!(encoded, alloy_rlp::encode(legacy));
+        assert_eq!(encoded.len(), account.length());
         assert_eq!(TrieAccount::decode(&mut encoded.as_slice()).unwrap(), account);
+    }
+
+    #[cfg(feature = "account-ext")]
+    #[test]
+    fn extension_is_appended_verbatim() {
+        let account = TrieAccount {
+            extension: AccountExtension::copy_from_slice(&[0x01, 0x82, 0xaa, 0xbb]),
+            ..Default::default()
+        };
+        let encoded = alloy_rlp::encode(&account);
+        assert!(encoded.ends_with(&[0x01, 0x82, 0xaa, 0xbb]));
+        assert_eq!(encoded.len(), account.length());
+        assert_eq!(TrieAccount::decode(&mut encoded.as_slice()).unwrap(), account);
+        assert_ne!(account.trie_hash_slow(), TrieAccount::default().trie_hash_slow());
+    }
+
+    #[cfg(feature = "account-ext")]
+    #[test]
+    fn malformed_extension_is_rejected() {
+        let account = TrieAccount {
+            extension: AccountExtension::copy_from_slice(&[0x82, 0xaa]),
+            ..Default::default()
+        };
+        assert!(TrieAccount::decode(&mut alloy_rlp::encode(account).as_slice()).is_err());
     }
 }

--- a/src/account.rs
+++ b/src/account.rs
@@ -74,14 +74,17 @@ impl<E: TrieAccountExtension> TrieAccount<E> {
 
 /// Additional chain-specific fields appended to an account trie leaf's RLP list.
 ///
-/// Implementations encode zero or more complete RLP items. The unit type encodes no items, so
-/// The unit implementation emits no fields, so [`TrieAccount<()>`] is byte-for-byte compatible
+/// Implementations encode zero or more complete RLP items. The unit implementation emits no
+/// fields, so [`TrieAccount<()>`] is byte-for-byte compatible
 /// with the canonical four-field Ethereum account encoding.
 pub trait TrieAccountExtension: Sized {
     /// Returns the encoded length of all extension fields.
     fn payload_length(&self) -> usize;
 
     /// Appends all extension fields to an account RLP list payload.
+    ///
+    /// Must write exactly [`Self::payload_length`] bytes. Callers may provide a fixed-size
+    /// buffer to encode directly into shared storage without an intermediate allocation.
     fn encode_payload(&self, out: &mut dyn BufMut);
 
     /// Decodes the extension fields from the remaining account RLP list payload.

--- a/src/account.rs
+++ b/src/account.rs
@@ -154,15 +154,7 @@ impl<E: TrieAccountExtension> Decodable for TrieAccount<E> {
 #[cfg(feature = "serde")]
 mod quantity {
     use alloy_primitives::U64;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    /// Serializes a primitive number as a "quantity" hex string.
-    pub(crate) fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        U64::from(*value).serialize(serializer)
-    }
+    use serde::{Deserialize, Deserializer};
 
     /// Deserializes a primitive number from a "quantity" hex string.
     pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>

--- a/src/account_extension.rs
+++ b/src/account_extension.rs
@@ -5,7 +5,7 @@ use alloy_primitives::Bytes;
 use core::{cmp::Ordering, ops::Deref};
 use triomphe::ThinArc;
 
-/// An immutable account payload with a one-pointer inline representation.
+/// Raw, unencoded account bytes with a one-pointer inline representation.
 ///
 /// Empty payloads allocate nothing. Nonempty payloads store their length and bytes
 /// in one reference-counted allocation; cloning shares that allocation.
@@ -74,14 +74,25 @@ impl Eq for AccountExtension {}
 #[cfg(feature = "borsh")]
 impl borsh::BorshSerialize for AccountExtension {
     fn serialize<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
-        borsh::BorshSerialize::serialize(self.as_ref(), writer)
+        let len = u16::try_from(self.len()).map_err(|_| {
+            borsh::io::Error::new(
+                borsh::io::ErrorKind::InvalidInput,
+                "account extension exceeds u16 length",
+            )
+        })?;
+        writer.write_all(&len.to_be_bytes())?;
+        writer.write_all(self.as_ref())
     }
 }
 
 #[cfg(feature = "borsh")]
 impl borsh::BorshDeserialize for AccountExtension {
     fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
-        <Vec<u8> as borsh::BorshDeserialize>::deserialize_reader(reader).map(Self::from)
+        let mut len = [0; 2];
+        reader.read_exact(&mut len)?;
+        let mut bytes = alloc::vec![0; usize::from(u16::from_be_bytes(len))];
+        reader.read_exact(&mut bytes)?;
+        Ok(Self::from(bytes))
     }
 }
 
@@ -104,7 +115,13 @@ impl serde::Serialize for AccountExtension {
         if serializer.is_human_readable() {
             alloy_primitives::hex::serialize(self.as_ref(), serializer)
         } else {
-            serializer.serialize_bytes(self.as_ref())
+            use serde::ser::{Error, SerializeTuple};
+            let len = u16::try_from(self.len()).map_err(S::Error::custom)?;
+            // A tuple avoids the serializer's native sequence-length prefix.
+            let mut tuple = serializer.serialize_tuple(2)?;
+            tuple.serialize_element(&len.to_be_bytes())?;
+            tuple.serialize_element(&RawBytes(self.as_ref()))?;
+            tuple.end()
         }
     }
 }
@@ -112,15 +129,124 @@ impl serde::Serialize for AccountExtension {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AccountExtension {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Bytes::deserialize(deserializer).map(Self::from)
+        if deserializer.is_human_readable() {
+            Bytes::deserialize(deserializer).map(Self::from)
+        } else {
+            deserializer.deserialize_tuple(2, ExtensionVisitor)
+        }
+    }
+}
+
+// Binary extensions use a fixed big-endian u16 length followed by raw bytes, including
+// a zero length for empty payloads so fields embedded in larger records stay delimited.
+#[cfg(feature = "serde")]
+struct RawBytes<'a>(&'a [u8]);
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for RawBytes<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeTuple;
+        let mut tuple = serializer.serialize_tuple(self.0.len())?;
+        for byte in self.0 {
+            tuple.serialize_element(byte)?;
+        }
+        tuple.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+struct ExtensionVisitor;
+
+#[cfg(feature = "serde")]
+impl<'de> serde::de::Visitor<'de> for ExtensionVisitor {
+    type Value = AccountExtension;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("a u16 length followed by raw account extension bytes")
+    }
+
+    fn visit_seq<A: serde::de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+        use serde::de::Error;
+        let len = u16::from_be_bytes(
+            seq.next_element()?.ok_or_else(|| A::Error::custom("missing extension length"))?,
+        );
+        seq.next_element_seed(PayloadVisitor(usize::from(len)))?
+            .ok_or_else(|| A::Error::custom("missing extension payload"))
+    }
+}
+
+#[cfg(feature = "serde")]
+struct PayloadVisitor(usize);
+
+#[cfg(feature = "serde")]
+impl<'de> serde::de::DeserializeSeed<'de> for PayloadVisitor {
+    type Value = AccountExtension;
+
+    fn deserialize<D: serde::Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_tuple(self.0, self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::de::Visitor<'de> for PayloadVisitor {
+    type Value = AccountExtension;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} raw account extension bytes", self.0)
+    }
+
+    fn visit_seq<A: serde::de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+        use serde::de::Error;
+        let mut bytes = Vec::with_capacity(self.0);
+        for i in 0..self.0 {
+            bytes.push(seq.next_element()?.ok_or_else(|| A::Error::invalid_length(i, &self))?);
+        }
+        Ok(AccountExtension::from(bytes))
     }
 }
 
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for AccountExtension {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        // Extensions must be complete RLP items.
         let bytes = <Vec<u8> as arbitrary::Arbitrary>::arbitrary(u)?;
-        Ok(Self::copy_from_slice(&alloy_rlp::encode(bytes)))
+        Ok(Self::from(bytes))
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_bytes_wire_format() {
+        for payload in [&[][..], &[0x82, 0xaa][..], &[42; 256][..]] {
+            let extension = AccountExtension::copy_from_slice(payload);
+            let mut expected = (payload.len() as u16).to_be_bytes().to_vec();
+            expected.extend_from_slice(payload);
+            let encoded = bincode::serialize(&extension).unwrap();
+            assert_eq!(encoded, expected);
+            assert_eq!(bincode::deserialize::<AccountExtension>(&encoded).unwrap(), extension);
+            let pair = (extension.clone(), 42u8);
+            assert_eq!(
+                bincode::deserialize::<(AccountExtension, u8)>(&bincode::serialize(&pair).unwrap())
+                    .unwrap(),
+                pair
+            );
+            let json = serde_json::to_string(&extension).unwrap();
+            assert_eq!(serde_json::from_str::<AccountExtension>(&json).unwrap(), extension);
+            if !payload.is_empty() {
+                assert!(
+                    bincode::deserialize::<AccountExtension>(&encoded[..encoded.len() - 1])
+                        .is_err()
+                );
+            }
+        }
+        assert!(
+            bincode::serialize(&AccountExtension::from(alloc::vec![0; usize::from(u16::MAX) + 1]))
+                .is_err()
+        );
     }
 }

--- a/src/account_extension.rs
+++ b/src/account_extension.rs
@@ -1,0 +1,126 @@
+//! Shared chain-specific account payloads.
+
+use alloc::vec::Vec;
+use alloy_primitives::Bytes;
+use core::{cmp::Ordering, ops::Deref};
+use triomphe::ThinArc;
+
+/// An immutable account payload with a one-pointer inline representation.
+///
+/// Empty payloads allocate nothing. Nonempty payloads store their length and bytes
+/// in one reference-counted allocation; cloning shares that allocation.
+#[derive(Clone, Debug, Default)]
+pub struct AccountExtension(Option<ThinArc<(), u8>>);
+
+impl AccountExtension {
+    /// Takes ownership of a shared payload without copying its bytes.
+    pub fn from_shared(payload: Option<ThinArc<(), u8>>) -> Self {
+        Self(payload.filter(|arc| !arc.slice.is_empty()))
+    }
+
+    /// Transfers the shared allocation without copying its bytes.
+    pub fn into_shared(self) -> Option<ThinArc<(), u8>> {
+        self.0
+    }
+
+    /// Creates an empty payload without allocating.
+    pub const fn new() -> Self {
+        Self(None)
+    }
+
+    /// Copies bytes into a single shared allocation.
+    pub fn copy_from_slice(bytes: &[u8]) -> Self {
+        Self((!bytes.is_empty()).then(|| ThinArc::from_header_and_slice((), bytes)))
+    }
+
+    /// Returns whether the payload is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_none()
+    }
+}
+
+impl AsRef<[u8]> for AccountExtension {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref().map_or(&[], |arc| &arc.slice)
+    }
+}
+
+impl Deref for AccountExtension {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        self.as_ref()
+    }
+}
+
+impl From<Bytes> for AccountExtension {
+    fn from(bytes: Bytes) -> Self {
+        Self::copy_from_slice(&bytes)
+    }
+}
+
+impl From<Vec<u8>> for AccountExtension {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self::copy_from_slice(&bytes)
+    }
+}
+
+impl PartialEq for AccountExtension {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+impl Eq for AccountExtension {}
+
+#[cfg(feature = "borsh")]
+impl borsh::BorshSerialize for AccountExtension {
+    fn serialize<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
+        borsh::BorshSerialize::serialize(self.as_ref(), writer)
+    }
+}
+
+#[cfg(feature = "borsh")]
+impl borsh::BorshDeserialize for AccountExtension {
+    fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+        <Vec<u8> as borsh::BorshDeserialize>::deserialize_reader(reader).map(Self::from)
+    }
+}
+
+impl PartialOrd for AccountExtension {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AccountExtension {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Order payload bytes, not ThinArc's length header.
+        self.as_ref().cmp(other.as_ref())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for AccountExtension {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            alloy_primitives::hex::serialize(self.as_ref(), serializer)
+        } else {
+            serializer.serialize_bytes(self.as_ref())
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for AccountExtension {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Bytes::deserialize(deserializer).map(Self::from)
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for AccountExtension {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // Extensions must be complete RLP items.
+        let bytes = <Vec<u8> as arbitrary::Arbitrary>::arbitrary(u)?;
+        Ok(Self::copy_from_slice(&alloy_rlp::encode(bytes)))
+    }
+}

--- a/src/account_extension.rs
+++ b/src/account_extension.rs
@@ -226,27 +226,31 @@ mod tests {
             let extension = AccountExtension::copy_from_slice(payload);
             let mut expected = (payload.len() as u16).to_be_bytes().to_vec();
             expected.extend_from_slice(payload);
-            let encoded = bincode::serialize(&extension).unwrap();
+            let encoded = postcard::to_allocvec(&extension).unwrap();
             assert_eq!(encoded, expected);
-            assert_eq!(bincode::deserialize::<AccountExtension>(&encoded).unwrap(), extension);
+            assert_eq!(postcard::from_bytes::<AccountExtension>(&encoded).unwrap(), extension);
             let pair = (extension.clone(), 42u8);
             assert_eq!(
-                bincode::deserialize::<(AccountExtension, u8)>(&bincode::serialize(&pair).unwrap())
-                    .unwrap(),
+                postcard::from_bytes::<(AccountExtension, u8)>(
+                    &postcard::to_allocvec(&pair).unwrap()
+                )
+                .unwrap(),
                 pair
             );
             let json = serde_json::to_string(&extension).unwrap();
             assert_eq!(serde_json::from_str::<AccountExtension>(&json).unwrap(), extension);
             if !payload.is_empty() {
                 assert!(
-                    bincode::deserialize::<AccountExtension>(&encoded[..encoded.len() - 1])
+                    postcard::from_bytes::<AccountExtension>(&encoded[..encoded.len() - 1])
                         .is_err()
                 );
             }
         }
         assert!(
-            bincode::serialize(&AccountExtension::from(alloc::vec![0; usize::from(u16::MAX) + 1]))
-                .is_err()
+            postcard::to_allocvec(&AccountExtension::from(
+                alloc::vec![0; usize::from(u16::MAX) + 1]
+            ))
+            .is_err()
         );
     }
 }

--- a/src/account_extension.rs
+++ b/src/account_extension.rs
@@ -9,6 +9,9 @@ use triomphe::ThinArc;
 ///
 /// Empty payloads allocate nothing. Nonempty payloads store their length and bytes
 /// in one reference-counted allocation; cloning shares that allocation.
+///
+/// Accounts omit empty extensions in Serde. Their binary representation requires
+/// struct boundaries, as in MessagePack; bincode and Postcard are not supported.
 #[derive(Clone, Debug, Default)]
 pub struct AccountExtension(Option<ThinArc<(), u8>>);
 
@@ -115,13 +118,7 @@ impl serde::Serialize for AccountExtension {
         if serializer.is_human_readable() {
             alloy_primitives::hex::serialize(self.as_ref(), serializer)
         } else {
-            use serde::ser::{Error, SerializeTuple};
-            let len = u16::try_from(self.len()).map_err(S::Error::custom)?;
-            // A tuple avoids the serializer's native sequence-length prefix.
-            let mut tuple = serializer.serialize_tuple(2)?;
-            tuple.serialize_element(&len.to_be_bytes())?;
-            tuple.serialize_element(&RawBytes(self.as_ref()))?;
-            tuple.end()
+            serializer.serialize_bytes(self.as_ref())
         }
     }
 }
@@ -129,82 +126,7 @@ impl serde::Serialize for AccountExtension {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AccountExtension {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        if deserializer.is_human_readable() {
-            Bytes::deserialize(deserializer).map(Self::from)
-        } else {
-            deserializer.deserialize_tuple(2, ExtensionVisitor)
-        }
-    }
-}
-
-// Binary extensions use a fixed big-endian u16 length followed by raw bytes, including
-// a zero length for empty payloads so fields embedded in larger records stay delimited.
-#[cfg(feature = "serde")]
-struct RawBytes<'a>(&'a [u8]);
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for RawBytes<'_> {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::SerializeTuple;
-        let mut tuple = serializer.serialize_tuple(self.0.len())?;
-        for byte in self.0 {
-            tuple.serialize_element(byte)?;
-        }
-        tuple.end()
-    }
-}
-
-#[cfg(feature = "serde")]
-struct ExtensionVisitor;
-
-#[cfg(feature = "serde")]
-impl<'de> serde::de::Visitor<'de> for ExtensionVisitor {
-    type Value = AccountExtension;
-
-    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str("a u16 length followed by raw account extension bytes")
-    }
-
-    fn visit_seq<A: serde::de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-        use serde::de::Error;
-        let len = u16::from_be_bytes(
-            seq.next_element()?.ok_or_else(|| A::Error::custom("missing extension length"))?,
-        );
-        seq.next_element_seed(PayloadVisitor(usize::from(len)))?
-            .ok_or_else(|| A::Error::custom("missing extension payload"))
-    }
-}
-
-#[cfg(feature = "serde")]
-struct PayloadVisitor(usize);
-
-#[cfg(feature = "serde")]
-impl<'de> serde::de::DeserializeSeed<'de> for PayloadVisitor {
-    type Value = AccountExtension;
-
-    fn deserialize<D: serde::Deserializer<'de>>(
-        self,
-        deserializer: D,
-    ) -> Result<Self::Value, D::Error> {
-        deserializer.deserialize_tuple(self.0, self)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::de::Visitor<'de> for PayloadVisitor {
-    type Value = AccountExtension;
-
-    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{} raw account extension bytes", self.0)
-    }
-
-    fn visit_seq<A: serde::de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-        use serde::de::Error;
-        let mut bytes = Vec::with_capacity(self.0);
-        for i in 0..self.0 {
-            bytes.push(seq.next_element()?.ok_or_else(|| A::Error::invalid_length(i, &self))?);
-        }
-        Ok(AccountExtension::from(bytes))
+        Bytes::deserialize(deserializer).map(Self::from)
     }
 }
 
@@ -224,8 +146,7 @@ mod tests {
     fn raw_bytes_wire_format() {
         for payload in [&[][..], &[0x82, 0xaa][..], &[42; 256][..]] {
             let extension = AccountExtension::copy_from_slice(payload);
-            let mut expected = (payload.len() as u16).to_be_bytes().to_vec();
-            expected.extend_from_slice(payload);
+            let expected = postcard::to_allocvec(&Bytes::copy_from_slice(payload)).unwrap();
             let encoded = postcard::to_allocvec(&extension).unwrap();
             assert_eq!(encoded, expected);
             assert_eq!(postcard::from_bytes::<AccountExtension>(&encoded).unwrap(), extension);
@@ -246,11 +167,5 @@ mod tests {
                 );
             }
         }
-        assert!(
-            postcard::to_allocvec(&AccountExtension::from(
-                alloc::vec![0; usize::from(u16::MAX) + 1]
-            ))
-            .is_err()
-        );
     }
 }

--- a/src/account_extension.rs
+++ b/src/account_extension.rs
@@ -77,25 +77,14 @@ impl Eq for AccountExtension {}
 #[cfg(feature = "borsh")]
 impl borsh::BorshSerialize for AccountExtension {
     fn serialize<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
-        let len = u16::try_from(self.len()).map_err(|_| {
-            borsh::io::Error::new(
-                borsh::io::ErrorKind::InvalidInput,
-                "account extension exceeds u16 length",
-            )
-        })?;
-        writer.write_all(&len.to_be_bytes())?;
-        writer.write_all(self.as_ref())
+        self.as_ref().serialize(writer)
     }
 }
 
 #[cfg(feature = "borsh")]
 impl borsh::BorshDeserialize for AccountExtension {
     fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
-        let mut len = [0; 2];
-        reader.read_exact(&mut len)?;
-        let mut bytes = alloc::vec![0; usize::from(u16::from_be_bytes(len))];
-        reader.read_exact(&mut bytes)?;
-        Ok(Self::from(bytes))
+        <Vec<u8>>::deserialize_reader(reader).map(Self::from)
     }
 }
 
@@ -167,5 +156,18 @@ mod tests {
                 );
             }
         }
+    }
+}
+
+#[cfg(all(test, feature = "borsh"))]
+mod borsh_tests {
+    use super::*;
+
+    #[test]
+    fn uses_standard_byte_vector_encoding() {
+        let extension = AccountExtension::copy_from_slice(&[0x82, 0xaa]);
+        let encoded = borsh::to_vec(&extension).unwrap();
+        assert_eq!(encoded, borsh::to_vec(&vec![0x82u8, 0xaa]).unwrap());
+        assert_eq!(borsh::from_slice::<AccountExtension>(&encoded).unwrap(), extension);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub mod proof;
 #[cfg(feature = "ethereum")]
 mod account;
 #[cfg(feature = "ethereum")]
-pub use account::TrieAccount;
+pub use account::{TrieAccount, TrieAccountExtension};
 
 mod mask;
 pub use mask::{TrieMask, TrieMaskIter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,12 @@ pub mod proof;
 
 #[cfg(feature = "ethereum")]
 mod account;
+#[cfg(feature = "account-ext")]
+mod account_extension;
 #[cfg(feature = "ethereum")]
-pub use account::{TrieAccount, TrieAccountExtension};
+pub use account::TrieAccount;
+#[cfg(feature = "account-ext")]
+pub use account_extension::AccountExtension;
 
 mod mask;
 pub use mask::{TrieMask, TrieMaskIter};

--- a/src/root.rs
+++ b/src/root.rs
@@ -117,9 +117,13 @@ mod ethereum {
     /// Hashes and sorts account keys, then proceeds to calculating the root hash of the state
     /// represented as MPT.
     /// See [`state_root_unsorted`] for more info.
-    pub fn state_root_ref_unhashed<'a, A: Into<TrieAccount> + Clone + 'a>(
+    pub fn state_root_ref_unhashed<'a, A, E>(
         state: impl IntoIterator<Item = (&'a Address, &'a A)>,
-    ) -> B256 {
+    ) -> B256
+    where
+        A: Into<TrieAccount<E>> + Clone + 'a,
+        E: crate::TrieAccountExtension,
+    {
         state_root_unsorted(
             state.into_iter().map(|(address, account)| (keccak256(address), account.clone())),
         )
@@ -128,9 +132,11 @@ mod ethereum {
     /// Hashes and sorts account keys, then proceeds to calculating the root hash of the state
     /// represented as MPT.
     /// See [`state_root_unsorted`] for more info.
-    pub fn state_root_unhashed<A: Into<TrieAccount>>(
-        state: impl IntoIterator<Item = (Address, A)>,
-    ) -> B256 {
+    pub fn state_root_unhashed<A, E>(state: impl IntoIterator<Item = (Address, A)>) -> B256
+    where
+        A: Into<TrieAccount<E>>,
+        E: crate::TrieAccountExtension,
+    {
         state_root_unsorted(
             state.into_iter().map(|(address, account)| (keccak256(address), account)),
         )
@@ -138,9 +144,11 @@ mod ethereum {
 
     /// Sorts the hashed account keys and calculates the root hash of the state represented as MPT.
     /// See [`state_root`] for more info.
-    pub fn state_root_unsorted<A: Into<TrieAccount>>(
-        state: impl IntoIterator<Item = (B256, A)>,
-    ) -> B256 {
+    pub fn state_root_unsorted<A, E>(state: impl IntoIterator<Item = (B256, A)>) -> B256
+    where
+        A: Into<TrieAccount<E>>,
+        E: crate::TrieAccountExtension,
+    {
         let mut vec = Vec::from_iter(state);
         vec.sort_unstable_by_key(|(key, _)| *key);
         state_root(vec)
@@ -153,7 +161,11 @@ mod ethereum {
     /// # Panics
     ///
     /// If the items are not in sorted order.
-    pub fn state_root<A: Into<TrieAccount>>(state: impl IntoIterator<Item = (B256, A)>) -> B256 {
+    pub fn state_root<A, E>(state: impl IntoIterator<Item = (B256, A)>) -> B256
+    where
+        A: Into<TrieAccount<E>>,
+        E: crate::TrieAccountExtension,
+    {
         let mut hb = HashBuilder::default();
         let mut account_rlp_buf = Vec::new();
         for (hashed_key, account) in state {

--- a/src/root.rs
+++ b/src/root.rs
@@ -117,13 +117,9 @@ mod ethereum {
     /// Hashes and sorts account keys, then proceeds to calculating the root hash of the state
     /// represented as MPT.
     /// See [`state_root_unsorted`] for more info.
-    pub fn state_root_ref_unhashed<'a, A, E>(
+    pub fn state_root_ref_unhashed<'a, A: Into<TrieAccount> + Clone + 'a>(
         state: impl IntoIterator<Item = (&'a Address, &'a A)>,
-    ) -> B256
-    where
-        A: Into<TrieAccount<E>> + Clone + 'a,
-        E: crate::TrieAccountExtension,
-    {
+    ) -> B256 {
         state_root_unsorted(
             state.into_iter().map(|(address, account)| (keccak256(address), account.clone())),
         )
@@ -132,11 +128,9 @@ mod ethereum {
     /// Hashes and sorts account keys, then proceeds to calculating the root hash of the state
     /// represented as MPT.
     /// See [`state_root_unsorted`] for more info.
-    pub fn state_root_unhashed<A, E>(state: impl IntoIterator<Item = (Address, A)>) -> B256
-    where
-        A: Into<TrieAccount<E>>,
-        E: crate::TrieAccountExtension,
-    {
+    pub fn state_root_unhashed<A: Into<TrieAccount>>(
+        state: impl IntoIterator<Item = (Address, A)>,
+    ) -> B256 {
         state_root_unsorted(
             state.into_iter().map(|(address, account)| (keccak256(address), account)),
         )
@@ -144,11 +138,9 @@ mod ethereum {
 
     /// Sorts the hashed account keys and calculates the root hash of the state represented as MPT.
     /// See [`state_root`] for more info.
-    pub fn state_root_unsorted<A, E>(state: impl IntoIterator<Item = (B256, A)>) -> B256
-    where
-        A: Into<TrieAccount<E>>,
-        E: crate::TrieAccountExtension,
-    {
+    pub fn state_root_unsorted<A: Into<TrieAccount>>(
+        state: impl IntoIterator<Item = (B256, A)>,
+    ) -> B256 {
         let mut vec = Vec::from_iter(state);
         vec.sort_unstable_by_key(|(key, _)| *key);
         state_root(vec)
@@ -161,11 +153,7 @@ mod ethereum {
     /// # Panics
     ///
     /// If the items are not in sorted order.
-    pub fn state_root<A, E>(state: impl IntoIterator<Item = (B256, A)>) -> B256
-    where
-        A: Into<TrieAccount<E>>,
-        E: crate::TrieAccountExtension,
-    {
+    pub fn state_root<A: Into<TrieAccount>>(state: impl IntoIterator<Item = (B256, A)>) -> B256 {
         let mut hb = HashBuilder::default();
         let mut account_rlp_buf = Vec::new();
         for (hashed_key, account) in state {


### PR DESCRIPTION
Adds an optional ThinArc-backed raw account payload behind `account-ext`. Account leaves remain four-field RLP lists for empty payloads and gain one byte-string field for nonempty payloads. Binary payload serialization uses a fixed u16 length followed by raw bytes.